### PR TITLE
fix: Hangin Garden bug fixes and adjustments

### DIFF
--- a/packages/hanging-garden/src/Garden.tsx
+++ b/packages/hanging-garden/src/Garden.tsx
@@ -32,7 +32,7 @@ type GardenProps = {
   provideController?: MutableRefObject<GardenController | null>;
 };
 
-function Garden<T extends HangingGardenColumnIndex>({ provideController }: GardenProps) {
+function Garden<T extends HangingGardenColumnIndex>({ provideController }: GardenProps): JSX.Element {
   const {
     pixiApp,
     container,

--- a/packages/hanging-garden/src/HangingGarden.tsx
+++ b/packages/hanging-garden/src/HangingGarden.tsx
@@ -37,6 +37,9 @@ const useStyles = makeStyles(() =>
       flex: '1 1 auto',
       height: '100%',
       minWidth: 0,
+      minHeight: 0,
+      maxWidth: '100%',
+      maxHeight: '100%',
     },
   })
 );

--- a/packages/hanging-garden/src/HangingGarden.tsx
+++ b/packages/hanging-garden/src/HangingGarden.tsx
@@ -56,7 +56,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   provideController,
   backgroundColor = 0xffffff,
   colorMode = 'Regular',
-}: HangingGardenProps<T>) {
+}: HangingGardenProps<T>): JSX.Element {
   const [maxRowCount, setMaxRowCount] = useState(0);
   const [expandedColumns, setExpandedColumns] = useState<ExpandedColumns>({});
 

--- a/packages/hanging-garden/src/HangingGarden.tsx
+++ b/packages/hanging-garden/src/HangingGarden.tsx
@@ -28,6 +28,7 @@ import { makeStyles, createStyles } from '@equinor/fusion-react-styles';
  * @param headerHeight The height of the column header. Defaults to 32,
  * @param provideController Returns a ref. this contains the renderGarden function. Used to trigger rerenders at will.
  * @param backgroundColor Backgroun color for the garden. Defaults to  white(0xffffff),
+ * @param disableScrollToHighlightedItem Per default garden centers column of clicked item. This disables that interaction.
  */
 
 const useStyles = makeStyles(() =>
@@ -59,6 +60,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   provideController,
   backgroundColor = 0xffffff,
   colorMode = 'Regular',
+  disableScrollToHighlightedItem = false,
 }: HangingGardenProps<T>): JSX.Element {
   const [maxRowCount, setMaxRowCount] = useState(0);
   const [expandedColumns, setExpandedColumns] = useState<ExpandedColumns>({});
@@ -67,7 +69,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   const canvas = useRef<HTMLCanvasElement>(null);
   const stage = useRef<PIXI.Container>(new PIXI.Container());
 
-  const scroll = useScrolling<T>(canvas, container, itemKeyProp);
+  const scroll = useScrolling<T>(canvas, container, itemKeyProp, disableScrollToHighlightedItem);
   const textureCaches = useTextureCaches();
   const popover = usePopover();
 

--- a/packages/hanging-garden/src/components/PopoverContainer/Arrow.tsx
+++ b/packages/hanging-garden/src/components/PopoverContainer/Arrow.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const Arrow = () => {
+const Arrow = (): JSX.Element => {
   const styles = useStyles();
   return (
     <svg

--- a/packages/hanging-garden/src/hooks/useHangingGardenData.tsx
+++ b/packages/hanging-garden/src/hooks/useHangingGardenData.tsx
@@ -2,6 +2,7 @@ import { useHangingGardenGetData } from './useHangingGardenGetData';
 import { formatDistance } from 'date-fns';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { HttpResponse } from '@equinor/fusion/lib/http/HttpClient';
+import { GardenDataError } from '../models/GardenDataError';
 
 /**
  * The useHangingGardenData hook fetched and stores your raw garden data. It also gives you cache invalidation capabilities and error handling. 
@@ -42,11 +43,21 @@ export const setItemSearchableValues = (commpkg: HandoverPackage) => ({
     );
  */
 
+type UseHangingGardenData<T> = {
+  data: T[];
+  error: GardenDataError | null;
+  isFetching: boolean;
+  retry: () => void;
+  invalidate: () => void;
+  cacheIsInvalid: boolean;
+  cacheAge: string;
+};
+
 export const useHangingGardenData = <T,>(
   getDataAsync: (invalidateCache: boolean) => Promise<HttpResponse<T[]>>,
   applyToFetchedData?: ((data: T[]) => T[]) | null,
   searchableValues?: ((data: T) => T) | null
-) => {
+): UseHangingGardenData<T> => {
   const { isFetching, error, getData } = useHangingGardenGetData<T>(getDataAsync);
   const [data, setData] = useState<T[]>([]);
 

--- a/packages/hanging-garden/src/hooks/useHangingGardenErrorMessage.tsx
+++ b/packages/hanging-garden/src/hooks/useHangingGardenErrorMessage.tsx
@@ -16,11 +16,16 @@ import { GardenDataError, ErrorMessageProps } from '../models/GardenDataError';
  *   const { errorMessage } = useHangingGardenErrorMessage('handover', error, retry);
  *   return(<ErrorMessage {...errorMessage}>{children}</ErrorMessage>)
  */
+
+type UseHangingGardenErrorMessage = {
+  errorMessage: ErrorMessageProps | null;
+};
+
 export const useHangingGardenErrorMessage = (
   resourceName: string,
   error: GardenDataError | null,
   onTakeAction: () => void
-) => {
+): UseHangingGardenErrorMessage => {
   const [errorMessage, setErrorMessage] = useState<ErrorMessageProps | null>(null);
 
   const buildErrorMessage = useCallback(

--- a/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
+++ b/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
@@ -15,14 +15,10 @@ import { useState, useCallback } from 'react';
  *
  */
 
+type GetDataPromise<T> = { data: T[]; cacheAge: Date; cacheDurationInMinutes: number };
+
 type UseHangingGardenGetData<T> = {
-  getData: (
-    invalidateCache?: boolean | undefined
-  ) => Promise<{
-    data: T[];
-    cacheAge: Date;
-    cacheDurationInMinutes: number;
-  } | null>;
+  getData: (invalidateCache?: boolean) => Promise<GetDataPromise<T> | null>;
   error: GardenDataError | null;
   isFetching: boolean;
 };

--- a/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
+++ b/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
@@ -14,7 +14,22 @@ import { useState, useCallback } from 'react';
  * const data = await getData(currentContext.id, true);
  *
  */
-export const useHangingGardenGetData = <T,>(getDataAsync: (invalidateCache: boolean) => Promise<HttpResponse<T[]>>) => {
+
+type UseHangingGardenGetData<T> = {
+  getData: (
+    invalidateCache?: boolean | undefined
+  ) => Promise<{
+    data: T[];
+    cacheAge: Date;
+    cacheDurationInMinutes: number;
+  } | null>;
+  error: GardenDataError | null;
+  isFetching: boolean;
+};
+
+export const useHangingGardenGetData = <T,>(
+  getDataAsync: (invalidateCache: boolean) => Promise<HttpResponse<T[]>>
+): UseHangingGardenGetData<T> => {
   const [error, setError] = useState<GardenDataError | null>(null);
   const [isFetching, setIsFetching] = useState(false);
 

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -27,4 +27,5 @@ export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   provideController?: MutableRefObject<GardenController | null>;
   backgroundColor?: number;
   colorMode?: ColorMode;
+  disableScrollToHighlightedItem?: boolean;
 };

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -6,15 +6,13 @@ export type HangingGardenColumn<T> = {
   data: T[];
 };
 
-export type HangingGardenColumnIndex = Record<string, any>;
+export type HangingGardenColumnIndex = Record<string, unknown>;
 
 export type GardenController = {
   clearGarden: () => void;
 };
 
-export type ColorMode = 'Regular' | 'Color blind';
-
-export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
+export type HangingGardenProps<T> = {
   columns: HangingGardenColumn<T>[];
   highlightedColumnKey: string | null;
   highlightedItem: T | null;

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -6,13 +6,13 @@ export type HangingGardenColumn<T> = {
   data: T[];
 };
 
-export type HangingGardenColumnIndex = Record<string, unknown>;
+export type HangingGardenColumnIndex = Record<string, any>;
 
 export type GardenController = {
   clearGarden: () => void;
 };
 
-export type HangingGardenProps<T> = {
+export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   columns: HangingGardenColumn<T>[];
   highlightedColumnKey: string | null;
   highlightedItem: T | null;

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -12,6 +12,8 @@ export type GardenController = {
   clearGarden: () => void;
 };
 
+export type ColorMode = 'Regular' | 'Color blind';
+
 export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   columns: HangingGardenColumn<T>[];
   highlightedColumnKey: string | null;

--- a/packages/hanging-garden/src/models/RenderContext.ts
+++ b/packages/hanging-garden/src/models/RenderContext.ts
@@ -26,7 +26,7 @@ export type HeaderRenderContext = RenderContext & {
 export type ItemRenderContext = RenderContext & {
   createRect: (position: Position, size: Size, color: number) => void;
   addDot: (color: number, position: Position, borderColor?: number) => void;
-  addPopover: (hitArea: any, renderPopover: () => JSX.Element) => void;
+  addPopover: (hitArea: PIXI.Rectangle, renderPopover: () => JSX.Element) => void;
   enquedRender: (key: string, render: (context: ItemRenderContext) => void) => void;
 };
 

--- a/packages/hanging-garden/src/renderHooks/useColumn.tsx
+++ b/packages/hanging-garden/src/renderHooks/useColumn.tsx
@@ -8,7 +8,12 @@ import useHeader from './useHeader';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useColumn = <T,>() => {
+
+type UseColumn<T> = {
+  renderColumn: (column: HangingGardenColumn<T>, index: number) => void;
+};
+
+const useColumn = <T,>(): UseColumn<T> => {
   const {
     scroll: { scrollTop },
     container,

--- a/packages/hanging-garden/src/renderHooks/useGarden.tsx
+++ b/packages/hanging-garden/src/renderHooks/useGarden.tsx
@@ -15,7 +15,12 @@ import useHightLightedItem from './useHightLightedItem';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useGarden = <T extends HangingGardenColumnIndex>() => {
+
+type UseGarden = {
+  renderGarden: () => void;
+};
+
+const useGarden = <T extends HangingGardenColumnIndex>(): UseGarden => {
   const {
     pixiApp,
     stage,

--- a/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
@@ -6,30 +6,29 @@ import { ItemRenderContext, HeaderRenderContext } from '../models/RenderContext'
 import { Scroll } from './useScrolling';
 import { UsePopover } from './usePopover';
 import { ColorMode } from '../models/HangingGarden';
-import { HangingGardenColumn, HangingGardenColumnIndex } from '../models/HangingGarden';
 
 export interface IHangingGardenContext {
   container: MutableRefObject<HTMLDivElement | null>;
   canvas: MutableRefObject<HTMLCanvasElement | null>;
   stage: MutableRefObject<PIXI.Container>;
   pixiApp: MutableRefObject<PIXI.Application | null>;
-  scroll: Scroll<HangingGardenColumnIndex>;
+  scroll: Scroll<any>;
   maxRowCount: number;
   setMaxRowCount: Dispatch<React.SetStateAction<number>>;
   expandedColumns: ExpandedColumns;
   setExpandedColumns: Dispatch<SetStateAction<Record<string, ExpandedColumn>>>;
   textureCaches: Caches;
   backgroundColor: number;
-  columns: HangingGardenColumn<unknown>[];
+  columns: unknown;
   itemKeyProp: unknown;
   itemHeight: number;
   itemWidth: number;
   headerHeight: number;
   highlightedItem: unknown;
   highlightedColumnKey: string | null;
-  getItemDescription: (item: unknown) => string;
-  onItemClick: (item: unknown) => void;
-  renderItemContext: (item: unknown, context: ItemRenderContext) => void;
+  getItemDescription: (item: any) => string;
+  onItemClick: (item: any) => void;
+  renderItemContext: (item: any, context: ItemRenderContext) => void;
   renderHeaderContext: (key: string, context: HeaderRenderContext) => void;
   popover: UsePopover;
   colorMode: ColorMode;
@@ -37,7 +36,6 @@ export interface IHangingGardenContext {
 
 const HangingGardenContext = createContext<IHangingGardenContext>({} as IHangingGardenContext);
 
-export const useHangingGardenContext = (): IHangingGardenContext =>
-  useContext<IHangingGardenContext>(HangingGardenContext);
+export const useHangingGardenContext = () => useContext<IHangingGardenContext>(HangingGardenContext);
 
 export default HangingGardenContext;

--- a/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
@@ -6,29 +6,30 @@ import { ItemRenderContext, HeaderRenderContext } from '../models/RenderContext'
 import { Scroll } from './useScrolling';
 import { UsePopover } from './usePopover';
 import { ColorMode } from '../models/HangingGarden';
+import { HangingGardenColumn, HangingGardenColumnIndex } from '../models/HangingGarden';
 
 export interface IHangingGardenContext {
   container: MutableRefObject<HTMLDivElement | null>;
   canvas: MutableRefObject<HTMLCanvasElement | null>;
   stage: MutableRefObject<PIXI.Container>;
   pixiApp: MutableRefObject<PIXI.Application | null>;
-  scroll: Scroll<any>;
+  scroll: Scroll<HangingGardenColumnIndex>;
   maxRowCount: number;
   setMaxRowCount: Dispatch<React.SetStateAction<number>>;
   expandedColumns: ExpandedColumns;
   setExpandedColumns: Dispatch<SetStateAction<Record<string, ExpandedColumn>>>;
   textureCaches: Caches;
   backgroundColor: number;
-  columns: unknown;
+  columns: HangingGardenColumn<unknown>[];
   itemKeyProp: unknown;
   itemHeight: number;
   itemWidth: number;
   headerHeight: number;
   highlightedItem: unknown;
   highlightedColumnKey: string | null;
-  getItemDescription: (item: any) => string;
-  onItemClick: (item: any) => void;
-  renderItemContext: (item: any, context: ItemRenderContext) => void;
+  getItemDescription: (item: unknown) => string;
+  onItemClick: (item: unknown) => void;
+  renderItemContext: (item: unknown, context: ItemRenderContext) => void;
   renderHeaderContext: (key: string, context: HeaderRenderContext) => void;
   popover: UsePopover;
   colorMode: ColorMode;

--- a/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
@@ -36,6 +36,7 @@ export interface IHangingGardenContext {
 
 const HangingGardenContext = createContext<IHangingGardenContext>({} as IHangingGardenContext);
 
-export const useHangingGardenContext = () => useContext<IHangingGardenContext>(HangingGardenContext);
+export const useHangingGardenContext = (): IHangingGardenContext =>
+  useContext<IHangingGardenContext>(HangingGardenContext);
 
 export default HangingGardenContext;

--- a/packages/hanging-garden/src/renderHooks/useHeader.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHeader.tsx
@@ -13,7 +13,12 @@ import useTextNode from './useTextNode';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useHeader = <T extends HangingGardenColumnIndex>() => {
+
+type UseHeader = {
+  renderHeader: (key: string, index: number) => void;
+};
+
+const useHeader = <T extends HangingGardenColumnIndex>(): UseHeader => {
   const {
     stage,
     expandedColumns,

--- a/packages/hanging-garden/src/renderHooks/useHightLightedItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHightLightedItem.tsx
@@ -11,7 +11,12 @@ import useRenderItem from './useItem';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useHightLightedItem = <T extends HangingGardenColumnIndex>() => {
+
+type UseHightLightedItem = {
+  renderHighlightedItem: () => void;
+};
+
+const useHightLightedItem = <T extends HangingGardenColumnIndex>(): UseHightLightedItem => {
   const {
     columns,
     itemKeyProp,

--- a/packages/hanging-garden/src/renderHooks/useHightLightedItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHightLightedItem.tsx
@@ -48,7 +48,7 @@ const useHightLightedItem = <T extends HangingGardenColumnIndex>(): UseHightLigh
         column.data.findIndex(
           (item) => item[itemKeyProp as keyof T] === (highlightedItem as T)[itemKeyProp as keyof T]
         ),
-        (columns as T).indexOf(column)
+        (columns as HangingGardenColumn<T>[]).indexOf(column)
       );
     }
   }, [highlightedItem, getTextureFromCache, addTextureToCache, stage.current, columns]);

--- a/packages/hanging-garden/src/renderHooks/useItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItem.tsx
@@ -71,7 +71,8 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
       const y = headerHeight + index * itemHeight;
       const key = `${item[itemKeyProp as keyof T]}_${colorMode}`;
       let renderedItem = getTextureFromCache('items', key) as PIXI.Container;
-      if (!renderedItem) {
+
+      if (!renderedItem || renderedItem.width !== itemWidth) {
         renderedItem = new PIXI.Container();
         renderedItem;
         renderedItem.x = x;

--- a/packages/hanging-garden/src/renderHooks/useItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItem.tsx
@@ -75,7 +75,6 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
       const y = headerHeight + index * itemHeight;
       const key = `${item[itemKeyProp as keyof T]}_${colorMode}`;
       let renderedItem = getTextureFromCache('items', key) as PIXI.Container;
-
       if (!renderedItem || renderedItem.width !== itemWidth) {
         renderedItem = new PIXI.Container();
         renderedItem;

--- a/packages/hanging-garden/src/renderHooks/useItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItem.tsx
@@ -17,7 +17,11 @@ import useItemDescription from './useItemDescription';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useItem = <T extends HangingGardenColumnIndex>() => {
+type UseItem<T> = {
+  renderItem: (item: T, index: number, columnIndex: number) => void;
+};
+
+const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
   const {
     pixiApp,
     stage,

--- a/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
@@ -13,7 +13,13 @@ import { HangingGardenColumn, HangingGardenColumnIndex } from '../models/Hanging
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useItemDescription = <T extends HangingGardenColumnIndex>() => {
+
+type UseItemDescription<T> = {
+  renderItemDescription: (item: T, index: number, columnIndex: number) => void;
+  getRenderedItemDescription: (item: T) => PIXI.Container;
+};
+
+const useItemDescription = <T extends HangingGardenColumnIndex>(): UseItemDescription<T> => {
   const {
     stage,
     backgroundColor,

--- a/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
@@ -37,13 +37,13 @@ const useItemDescription = <T extends HangingGardenColumnIndex>(): UseItemDescri
 
   const getRenderedItemDescription = useCallback(
     (item: T) => {
-      let itemDescription = getTextureFromCache('descriptions', item[itemKeyProp as keyof T]);
+      let itemDescription = getTextureFromCache('descriptions', item[itemKeyProp as keyof T] as string);
 
       if (!itemDescription) {
         const description = getItemDescription(item);
         const textNode = createTextNode(description, 0x243746);
         itemDescription = createRenderedItemDescription(backgroundColor, textNode);
-        addTextureToCache('descriptions', item[itemKeyProp as keyof T], itemDescription);
+        addTextureToCache('descriptions', item[itemKeyProp as keyof T] as string, itemDescription);
       }
       return itemDescription as PIXI.Container;
     },

--- a/packages/hanging-garden/src/renderHooks/usePixiApp.tsx
+++ b/packages/hanging-garden/src/renderHooks/usePixiApp.tsx
@@ -7,11 +7,15 @@ import * as PIXI from 'pixi.js-legacy';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
+type UsePixiApp = {
+  pixiApp: React.MutableRefObject<PIXI.Application | null>;
+};
+
 const usePixiApp = (
   canvas: React.RefObject<HTMLCanvasElement> | null,
   container: React.RefObject<HTMLDivElement> | null,
   backgroundColor: number
-) => {
+): UsePixiApp => {
   PIXI.utils.skipHello(); // Don't output the pixi message to the console
   PIXI.Ticker.shared.autoStart = false;
   PIXI.settings.ROUND_PIXELS = true;

--- a/packages/hanging-garden/src/renderHooks/useRenderQueue.tsx
+++ b/packages/hanging-garden/src/renderHooks/useRenderQueue.tsx
@@ -18,6 +18,7 @@ export type RenderQueue = {
 const useRenderQueue = (): RenderQueue => {
   const {
     pixiApp,
+    itemWidth,
     textureCaches: { getTextureFromCache, addTextureToCache },
   } = useHangingGardenContext();
 
@@ -59,7 +60,7 @@ const useRenderQueue = (): RenderQueue => {
     async (renderer: RenderItem) => {
       let graphicsContainer = getTextureFromCache('graphics', renderer.key) as PIXI.RenderTexture;
 
-      if (!graphicsContainer) {
+      if (!graphicsContainer || graphicsContainer.width !== itemWidth) {
         const graphics = new PIXI.Graphics();
         graphics.cacheAsBitmap = false;
         renderer.render({
@@ -77,7 +78,7 @@ const useRenderQueue = (): RenderQueue => {
 
       renderer.context.container.addChild(new PIXI.Sprite(graphicsContainer));
     },
-    [getTextureFromCache, addTextureToCache, pixiApp]
+    [getTextureFromCache, addTextureToCache, pixiApp, itemWidth]
   );
 
   return { enqueueRenderer, processRenderQueue, processRenderQueueAnimationFrame };

--- a/packages/hanging-garden/src/renderHooks/useRendererSize.tsx
+++ b/packages/hanging-garden/src/renderHooks/useRendererSize.tsx
@@ -53,7 +53,9 @@ const useRendererSize = (): void => {
 
     resizeObserverRef?.current?.observe(container.current);
 
-    return () => resizeObserverRef?.current?.unobserve(container.current);
+    return () => {
+      container?.current && resizeObserverRef?.current?.unobserve(container.current);
+    };
   }, [resizeRenderer]);
 
   return;

--- a/packages/hanging-garden/src/renderHooks/useRendererSize.tsx
+++ b/packages/hanging-garden/src/renderHooks/useRendererSize.tsx
@@ -3,7 +3,7 @@ import { useHangingGardenContext } from './useHangingGardenContext';
 import useGarden from './useGarden';
 
 declare class ResizeObserver {
-  constructor(callback: any);
+  constructor(callback: (arr: ResizeObserverArray[]) => void);
   observe: (target: Element | null) => void;
   unobserve: (target: Element | null) => void;
 }
@@ -20,7 +20,7 @@ type ResizeObserverArray = {
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useRendererSize = () => {
+const useRendererSize = (): void => {
   const { pixiApp, container } = useHangingGardenContext();
   const { renderGarden } = useGarden();
   const resizeObserverRef = React.useRef<ResizeObserver>();

--- a/packages/hanging-garden/src/renderHooks/useScrolling.tsx
+++ b/packages/hanging-garden/src/renderHooks/useScrolling.tsx
@@ -23,7 +23,8 @@ export type Scroll<T extends HangingGardenColumnIndex> = {
 const useScrolling = <T extends HangingGardenColumnIndex>(
   canvas: RefObject<HTMLCanvasElement> | null,
   container: RefObject<HTMLDivElement> | null,
-  itemKeyProp: keyof T
+  itemKeyProp: keyof T,
+  disableScrollToHighlightedItem?: boolean
 ): Scroll<T> => {
   const isScrolling = useRef(false);
   const scrollTop = useRef(0);
@@ -79,7 +80,7 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
 
   const scrollToHighlightedItem = useCallback(
     (columns: HangingGardenColumn<T>[], highlightedItem: T | null, itemWidth: number): boolean => {
-      if (!highlightedItem) return false;
+      if (disableScrollToHighlightedItem || !highlightedItem) return false;
       const highlightedIndex = columns.findIndex((column) =>
         column.data.some((item) => {
           return item[itemKeyProp] === highlightedItem[itemKeyProp];
@@ -88,7 +89,7 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
 
       return scrollTo(highlightedIndex, itemWidth);
     },
-    [scrollTo, itemKeyProp]
+    [scrollTo, itemKeyProp, disableScrollToHighlightedItem]
   );
 
   return {

--- a/packages/hanging-garden/src/renderHooks/useTextNode.tsx
+++ b/packages/hanging-garden/src/renderHooks/useTextNode.tsx
@@ -10,7 +10,12 @@ import { DEFAULT_ITEM_TEXT_STYLE } from '../utils';
  * This hook is used by the Garden and is not intended to be used or implemented
  * outside the Garden component.
  */
-const useTextNode = () => {
+
+type UseTextNode = {
+  createTextNode: (text: string, color: number) => PIXI.Sprite;
+};
+
+const useTextNode = (): UseTextNode => {
   const {
     pixiApp,
     stage,

--- a/packages/hanging-garden/src/renderHooks/useTextureCaches.tsx
+++ b/packages/hanging-garden/src/renderHooks/useTextureCaches.tsx
@@ -22,7 +22,7 @@ export type TextureCaches = {
   items: ContainerCache;
   chars: TextureCache;
   graphics: RenderTextureCache;
-  descriptions: any;
+  descriptions: ContainerCache;
   masks: GraphicsCache;
   texts: RenderTextureCache;
   rects: RenderTextureCache;

--- a/packages/hanging-garden/src/utils.ts
+++ b/packages/hanging-garden/src/utils.ts
@@ -16,16 +16,16 @@ export const DEFAULT_ITEM_TEXT_STYLE = new PIXI.TextStyle({
   align: 'center',
 });
 
-export const createTextStyle = (style: PIXI.TextStyle) => new PIXI.TextStyle(style);
+export const createTextStyle = (style: PIXI.TextStyle): PIXI.TextStyle => new PIXI.TextStyle(style);
 
-export const getMaxRowCount = (columns: HangingGardenColumn<any>[]) => {
+export const getMaxRowCount = (columns: HangingGardenColumn<unknown>[]): number => {
   return Math.max(...columns.map((column) => column.data.length));
 };
 
-export const getExpandedWith = (width: number, c: ExpandedColumn) =>
+export const getExpandedWith = (width: number, c: ExpandedColumn): number =>
   (width += c.maxWidth + EXPANDED_COLUMN_PADDING * 2);
 
-export const getColumnX = (index: number, currentExpandedColumns: ExpandedColumns, defaultWidth: number) => {
+export const getColumnX = (index: number, currentExpandedColumns: ExpandedColumns, defaultWidth: number): number => {
   const expandedWidthBeforeIndex = Object.values(currentExpandedColumns)
     .filter((c) => c.index < index && c.isExpanded)
     .reduce(getExpandedWith, 0);
@@ -33,18 +33,18 @@ export const getColumnX = (index: number, currentExpandedColumns: ExpandedColumn
   return index * defaultWidth + expandedWidthBeforeIndex;
 };
 
-export const isHeaderExpanded = (columnKey: string, expandedColumns: ExpandedColumns) =>
+export const isHeaderExpanded = (columnKey: string, expandedColumns: ExpandedColumns): boolean =>
   (expandedColumns && expandedColumns[columnKey])?.isExpanded;
 
-export const getHeaderWidth = (columnKey: string, expandedColumns: ExpandedColumns, defaultWidth: number) =>
+export const getHeaderWidth = (columnKey: string, expandedColumns: ExpandedColumns, defaultWidth: number): number =>
   isHeaderExpanded(columnKey, expandedColumns)
     ? defaultWidth + expandedColumns[columnKey].maxWidth + EXPANDED_COLUMN_PADDING * 2
     : defaultWidth;
 
-export const getCalculatedHeight = (headerHeight: number, itemHeight: number, maxRowCount: number) =>
+export const getCalculatedHeight = (headerHeight: number, itemHeight: number, maxRowCount: number): number =>
   maxRowCount ? headerHeight + itemHeight * maxRowCount : 0;
 
-export const addDot = (context: ItemRenderContext, color: number, position: Position, borderColor = 0xffffff) => {
+export const addDot = (context: ItemRenderContext, color: number, position: Position, borderColor = 0xffffff): void => {
   const circle = new PIXI.Circle(position.x, position.y, 2);
 
   context.graphics.lineStyle(1, borderColor, 1, 1);
@@ -58,14 +58,14 @@ export const getCalculatedWidth = (
   currentExpandedColumns: ExpandedColumns,
   columnsLength: number,
   itemWidth: number
-) => {
+): number => {
   const expandedWidth = Object.values(currentExpandedColumns)
     .filter((c) => c.isExpanded)
     .reduce(getExpandedWith, 0);
   return columnsLength * itemWidth + expandedWidth;
 };
 
-export const createRenderedItemDescription = (backgroundColor: number, textNode: PIXI.Sprite) => {
+export const createRenderedItemDescription = (backgroundColor: number, textNode: PIXI.Sprite): PIXI.Container => {
   const itemDescription = new PIXI.Container();
   itemDescription.cacheAsBitmap = true;
 
@@ -78,7 +78,7 @@ export const createRenderedItemDescription = (backgroundColor: number, textNode:
   return itemDescription;
 };
 
-export const createRoundedRectMask = (width: number, height: number) => {
+export const createRoundedRectMask = (width: number, height: number): PIXI.Graphics => {
   const mask = new PIXI.Graphics();
   mask.cacheAsBitmap = true;
   mask.beginFill(0xff3300);

--- a/storybook/stories/hanging-garden/demo/GardenDemo.tsx
+++ b/storybook/stories/hanging-garden/demo/GardenDemo.tsx
@@ -14,17 +14,17 @@ import { fetchGardenItemsAsync, getColumns, getYearAndWeekFromDate } from './col
 import ProjectPopover from './components/project-popover';
 import { createStyles, FusionTheme, makeStyles } from '@equinor/fusion-react-styles';
 
-
 import { useCallback } from 'react';
 import GardenItem from './models/garden-item';
+import { HttpResponse } from '@equinor/fusion/lib/http/HttpClient';
 
-const useStyles = makeStyles<FusionTheme, {height?:number}>(() =>
+const useStyles = makeStyles<FusionTheme, { height?: number }>(() =>
   createStyles({
-    root: ({height}) => ({
+    root: ({ height }) => ({
       height,
       display: 'flex',
       flex: '1 1 auto',
-      minWidth: 0
+      minWidth: 0,
     }),
   })
 );
@@ -32,12 +32,11 @@ const useStyles = makeStyles<FusionTheme, {height?:number}>(() =>
 export type GardenDemoProps = {
   rows?: number;
   height?: number;
-}
+};
 
-
-const GardenDemo: FC<GardenDemoProps> = ({rows, height}) => {
+const GardenDemo: FC<GardenDemoProps> = ({ rows, height }: GardenDemoProps) => {
   const getData = useCallback(async () => {
-    return await fetchGardenItemsAsync(rows);
+    return (await fetchGardenItemsAsync(rows)) as Promise<HttpResponse<GardenItem[]>>;
   }, [rows]);
 
   const { data, error, isFetching, retry } = useHangingGardenData<GardenItem>(getData);
@@ -56,13 +55,10 @@ const GardenDemo: FC<GardenDemoProps> = ({rows, height}) => {
     console.log('errorMessage', errorMessage);
   }, [errorMessage]);
 
-  const style = useStyles({height});
+  const style = useStyles({ height });
 
   const getItemWidth = () => {
-    const longestKey = Math.max.apply(
-      Math,
-      data.map((item) => item.id.length)
-    );
+    const longestKey = Math.max(...data.map((item) => item.id.length));
 
     return Math.max(longestKey * 8 + 35, 102);
   };

--- a/storybook/stories/hanging-garden/demo/columns/columns.ts
+++ b/storybook/stories/hanging-garden/demo/columns/columns.ts
@@ -3,7 +3,7 @@ import { HangingGardenColumn } from '@equinor/fusion-react-hanging-garden';
 import GardenItem, { ItemState } from '../models/garden-item';
 import { getStateOrder } from '../helpers';
 
-export const getColumns = (data: GardenItem[]) => {
+export const getColumns = (data: GardenItem[]): HangingGardenColumn<GardenItem>[] => {
   const highlightedKey = getYearAndWeekFromDate(new Date());
 
   const newColumns = data
@@ -27,9 +27,9 @@ export const getColumns = (data: GardenItem[]) => {
   return newColumns.sort(({ key: a }, { key: b }) => a.localeCompare(b));
 };
 
-export const getYearAndWeekFromDate = (date: Date) => format(date, 'yyyy/II', { weekStartsOn: 1 });
+export const getYearAndWeekFromDate = (date: Date): string => format(date, 'yyyy/II', { weekStartsOn: 1 });
 
-export const createDataSet = (itemsCount: number = 1000, dayDiff: number = 200): GardenItem[] => {
+export const createDataSet = (itemsCount = 1000, dayDiff = 200): GardenItem[] => {
   const states: ItemState[] = ['new', 'active', 'onhold', 'verification', 'closed'];
   const items: GardenItem[] = [];
   for (let item = 0; item < itemsCount; item++) {
@@ -47,8 +47,8 @@ export const createDataSet = (itemsCount: number = 1000, dayDiff: number = 200):
   return items;
 };
 
-export const fetchGardenItemsAsync = (itemsCount?: number, dayDiff?: number) =>
-  new Promise<any>((resolve) => {
+export const fetchGardenItemsAsync = (itemsCount?: number, dayDiff?: number): Promise<unknown> =>
+  new Promise<unknown>((resolve) => {
     resolve({
       status: 200,
       data: createDataSet(itemsCount, dayDiff),

--- a/storybook/stories/hanging-garden/demo/components/project-popover/index.tsx
+++ b/storybook/stories/hanging-garden/demo/components/project-popover/index.tsx
@@ -7,12 +7,12 @@ type ProjectPopoverType = {
 const useStyles = makeStyles(() =>
   createStyles({
     root: {
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
     },
   })
 );
 
-const ProjectPopover: React.FC<ProjectPopoverType> = ({ text }) => {
+const ProjectPopover: React.FC<ProjectPopoverType> = ({ text }: ProjectPopoverType) => {
   const styles = useStyles();
   return <div className={styles.root}>{text}</div>;
 };


### PR DESCRIPTION
a minor hack to get control over the caches
Sometimes items that should have been removed from the caches end up back in them.

This checks the rendereditem and the graphicsContainer widht. If they are not
the same as Garden ItemWidht, the cached version is discarded and recreated.

The renderedItem width makes sure the color gets sized properly.
The graphicsContainer makes sure the text get placed properly.