### PR TITLE
Feat/datepicker range selection

### DIFF
--- a/packages/datepicker/src/DatePicker.tsx
+++ b/packages/datepicker/src/DatePicker.tsx
@@ -163,9 +163,6 @@ export const FusionDatePicker: FunctionComponent<FusionDatePickerProps> = (
       renderCustomHeader={(props) => {
         return <FusionDatePickerHeader {...props} type={type} />;
       }}
-      onChangeRaw={(event) => {
-        console.log('RAW', event.target);
-      }}
       //dayClassName={(d) => clsx(classes.day, date && isSameDay(d, date) && classes.selectedDay)}
       selected={isRange ? dateFrom : date}
       selectsRange={isRange}

--- a/packages/datepicker/src/DatePickerHeader.tsx
+++ b/packages/datepicker/src/DatePickerHeader.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, forwardRef } from 'react';
 import { makeStyles, createStyles, theme, FusionTheme, clsx } from '@equinor/fusion-react-styles';
 import { format } from 'date-fns';
-import { DatePickerType } from './types';
+import { FusionDatePickerType } from './types';
 import DatePicker from 'react-datepicker';
 import Icon from './Icon';
 import { arrow_back, arrow_drop_down, arrow_forward } from '@equinor/eds-icons';
@@ -25,7 +25,7 @@ type HeaderProps = {
   nextYearButtonDisabled: boolean;
   prevMonthButtonDisabled: boolean;
   prevYearButtonDisabled: boolean;
-  type: DatePickerType;
+  type: FusionDatePickerType;
 };
 
 type InputProps = {

--- a/packages/datepicker/src/DatePickerInput.tsx
+++ b/packages/datepicker/src/DatePickerInput.tsx
@@ -77,6 +77,8 @@ export const FusionDatePickerInput = forwardRef<HTMLInputElement, InputHTMLAttri
       hasValue: props.value ? true : false,
     });
 
+    console.log('VALUE', props.value);
+
     return (
       <div className={classes.container}>
         <input {...rest} className={classes.input} ref={ref} />

--- a/packages/datepicker/src/types.ts
+++ b/packages/datepicker/src/types.ts
@@ -1,12 +1,13 @@
 export type FusionDatePickerProps = {
   allowKeyboardControl?: boolean;
   allowSameDay?: boolean;
-  date: Date | null | undefined;
+  date?: Date | null;
+  dateFrom?: Date | null;
+  dateTo?: Date | null;
   dateFormat?: string;
   disabled?: boolean;
   disableFuture?: boolean;
   disablePast?: boolean;
-  endDate?: Date;
   excludeDates?: Date[];
   excludeTimes?: Date[];
   filterDate?(date: Date): boolean;
@@ -16,17 +17,18 @@ export type FusionDatePickerProps = {
   injectTimes?: Date[];
   inline?: boolean;
   isClearable?: boolean;
-  locale?: Locale | undefined;
+  locale?: Locale;
   maxDate?: Date | null;
   maxTime?: Date;
   minDate?: Date | null;
   minTime?: Date;
   onBlur?(): void;
-  onChange(date: Date | null): void;
+  onChange?(date: Date | null): void;
   onClose?(): void;
   onFocus?(): void;
   onMonthChange?(date: Date): void;
   onOpen?(): void;
+  onRangeChange?(range: [Date | null, Date | null]): void;
   onYearChange?(date: Date): void;
   openToDate?: Date;
   placeholder?: string;
@@ -35,11 +37,10 @@ export type FusionDatePickerProps = {
   shouldCloseOnSelect?: boolean;
   showTodayButton?: boolean;
   showWeekNumbers?: boolean;
-  startDate?: Date;
   startOpen?: boolean;
   tabIndex?: number;
-  type?: DatePickerType;
+  type?: FusionDatePickerType;
   width?: string;
 };
 
-export type DatePickerType = 'year' | 'month' | 'date' | 'datetime' | 'time' | undefined;
+export type FusionDatePickerType = 'year' | 'month' | 'date' | 'date-range' | 'datetime' | 'time' | undefined;

--- a/storybook/stories/datepicker/datepicker.stories.tsx
+++ b/storybook/stories/datepicker/datepicker.stories.tsx
@@ -8,13 +8,30 @@ export default {
 } as Meta;
 
 const Template: Story<FusionDatePickerProps> = (args) => {
-  const [date, setDate] = useState<Date | null | undefined>();
+  const [date, setDate] = useState<Date | null>(null);
 
   return <FusionDatePicker {...args} onChange={setDate} date={date} />;
 };
 
-export const Date = Template.bind({});
-Date.args = { placeholder: 'Select date', type: 'date' };
+const RangeTemplate: Story<FusionDatePickerProps> = (args) => {
+  const [dateFrom, setDateFrom] = useState<Date | null>(null);
+  const [dateTo, setDateTo] = useState<Date | null>(null);
+
+  const setDateRange = (range: [Date | null, Date | null]) => {
+    console.log('setDateRange', range);
+    const [from, to] = range;
+    setDateFrom(from);
+    setDateTo(to);
+  };
+
+  return <FusionDatePicker {...args} onRangeChange={setDateRange} dateFrom={dateFrom} dateTo={dateTo} />;
+};
+
+export const Dates = Template.bind({});
+Dates.args = { placeholder: 'Select date', type: 'date' };
+
+export const DateRange = RangeTemplate.bind({});
+DateRange.args = { placeholder: 'Select date range (from-to)', type: 'date-range' };
 
 export const DateAndTime = Template.bind({});
 DateAndTime.args = {


### PR DESCRIPTION
Added support for date range selection. The support contains a workaroung to get around a react-datepicker bug related to range selection. See https://github.com/Hacker0x01/react-datepicker/issues/2959

There is still an issue where the date picker popper does not close after selection of a date-range and has to be closed manually. This will hopefully be fixed when the issue defined above is resolved.