### PR TITLE
feat: color mode hanging garden

### DIFF
--- a/packages/hanging-garden/src/HangingGarden.tsx
+++ b/packages/hanging-garden/src/HangingGarden.tsx
@@ -55,6 +55,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   headerHeight = DEFAULT_HEADER_HEIGHT,
   provideController,
   backgroundColor = 0xffffff,
+  colorMode = 'Regular',
 }: HangingGardenProps<T>) {
   const [maxRowCount, setMaxRowCount] = useState(0);
   const [expandedColumns, setExpandedColumns] = useState<ExpandedColumns>({});
@@ -103,6 +104,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
             renderItemContext,
             renderHeaderContext,
             popover,
+            colorMode,
           }}
         >
           <Garden<T> provideController={provideController} />

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -12,6 +12,8 @@ export type GardenController = {
   clearGarden: () => void;
 };
 
+export type ColorMode = 'Regular' | 'Color blind';
+
 export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   columns: HangingGardenColumn<T>[];
   highlightedColumnKey: string | null;
@@ -26,4 +28,5 @@ export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   renderHeaderContext: (key: string, context: HeaderRenderContext) => void;
   provideController?: MutableRefObject<GardenController | null>;
   backgroundColor?: number;
+  colorMode?: ColorMode;
 };

--- a/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
@@ -5,6 +5,7 @@ import { ExpandedColumns, ExpandedColumn } from '../models/ExpandedColumn';
 import { ItemRenderContext, HeaderRenderContext } from '../models/RenderContext';
 import { Scroll } from './useScrolling';
 import { UsePopover } from './usePopover';
+import { ColorMode } from '../models/HangingGarden';
 
 export interface IHangingGardenContext {
   container: MutableRefObject<HTMLDivElement | null>;
@@ -30,6 +31,7 @@ export interface IHangingGardenContext {
   renderItemContext: (item: any, context: ItemRenderContext) => void;
   renderHeaderContext: (key: string, context: HeaderRenderContext) => void;
   popover: UsePopover;
+  colorMode: ColorMode;
 }
 
 const HangingGardenContext = createContext<IHangingGardenContext>({} as IHangingGardenContext);

--- a/packages/hanging-garden/src/renderHooks/useItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItem.tsx
@@ -31,6 +31,7 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
     renderItemContext,
     textureCaches: { getTextureFromCache, addTextureToCache },
     popover: { addPopover },
+    colorMode,
   } = useHangingGardenContext();
 
   const { createTextNode } = useTextNode();
@@ -68,7 +69,8 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
     (item: T, index: number, columnIndex: number) => {
       const x = getColumnX(columnIndex, expandedColumns, itemWidth);
       const y = headerHeight + index * itemHeight;
-      let renderedItem = getTextureFromCache('items', item[itemKeyProp as keyof T]) as PIXI.Container;
+      const key = `${item[itemKeyProp as keyof T]}_${colorMode}`;
+      let renderedItem = getTextureFromCache('items', key) as PIXI.Container;
       if (!renderedItem) {
         renderedItem = new PIXI.Container();
         renderedItem;
@@ -110,7 +112,7 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
 
         renderItemContext(item, itemRenderContext);
 
-        addTextureToCache('items', item[itemKeyProp as keyof T], renderedItem);
+        addTextureToCache('items', key, renderedItem);
       }
 
       if (highlightedItem && (highlightedItem as T)[itemKeyProp as keyof T] === item[itemKeyProp as keyof T]) {
@@ -150,6 +152,7 @@ const useItem = <T extends HangingGardenColumnIndex>() => {
       processRenderQueue,
       renderItemDescription,
       onItemClick,
+      colorMode,
     ]
   );
 


### PR DESCRIPTION
## Color mode for Hanging Garden
The garden apps will have the option to turn on color blindness mode which will need a re-render to draw the new PIXI textures. The textures are cached by the Hanging Garden component. By passing through the colorMode prop from the app to the Hanging Garden component, and adding it to the cache key, PIXI will now re-render whenever color mode changes.