### PR TITLE
fix: ensure that the scroll to calcualtion does not endup being below 0

### DIFF
--- a/packages/hanging-garden/src/renderHooks/useScrolling.tsx
+++ b/packages/hanging-garden/src/renderHooks/useScrolling.tsx
@@ -55,13 +55,16 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
         return false;
       }
 
-      scrollLeft.current = container.current.scrollLeft = Math.max(
+      //Calculate how far from the left to scroll, while ensuring scroll is not below 0.
+      const scrollWindowTo = Math.max(
         highlightedColumnIndex >= 0
           ? (container.current.scrollLeft =
               highlightedColumnIndex * itemWidth - container.current.offsetWidth / 2 + itemWidth / 2)
           : 0,
         0
       );
+
+      scrollLeft.current = container.current.scrollLeft = scrollWindowTo;
 
       if (canvas?.current)
         canvas.current.style.transform = `translate(${scrollLeft.current}px, ${scrollTop.current}px)`;

--- a/packages/hanging-garden/src/renderHooks/useScrolling.tsx
+++ b/packages/hanging-garden/src/renderHooks/useScrolling.tsx
@@ -55,11 +55,13 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
         return false;
       }
 
-      scrollLeft.current =
+      scrollLeft.current = container.current.scrollLeft = Math.max(
         highlightedColumnIndex >= 0
           ? (container.current.scrollLeft =
               highlightedColumnIndex * itemWidth - container.current.offsetWidth / 2 + itemWidth / 2)
-          : 0;
+          : 0,
+        0
+      );
 
       if (canvas?.current)
         canvas.current.style.transform = `translate(${scrollLeft.current}px, ${scrollTop.current}px)`;


### PR DESCRIPTION
There was some scenariors where the scrollTo function could end up setting the scrollLeft to be below 0. 
While this this did not really have an effect on the scrolling. 
It would cause the render window to be calculated wrong. 
Typically the width of the "window" would shrunk accordinly to the negative scrollLeft, and the right side was just empty. 
Untill the user scrolled again. 

Typically this would happen when trying to center a highlighted item that was in  one of the first columns. 
As these columns dont always scroll to center, as there is nothing to the right of them.  
but the window still got cut as if they were scrolled to the center. 

This fix just set the scrollLeft to 0 if the calcuation is negative. 