### PR TITLE
feat: padding option and new dashed highlight border around packages

### DIFF
--- a/packages/hanging-garden/src/Garden.tsx
+++ b/packages/hanging-garden/src/Garden.tsx
@@ -47,6 +47,7 @@ function Garden<T extends HangingGardenColumnIndex>({ provideController }: Garde
     scroll: { onScroll },
     popover: { popover },
     groupLevels,
+    padding,
   } = useHangingGardenContext();
 
   const { renderGarden } = useGarden();
@@ -76,9 +77,9 @@ function Garden<T extends HangingGardenColumnIndex>({ provideController }: Garde
       width: getCalculatedWidth(
         expandedColumns,
         (columns as HangingGardenColumn<T>[]).length,
-        itemWidth + groupLevels * GROUP_LEVEL_OFFSET
+        itemWidth + padding + groupLevels * GROUP_LEVEL_OFFSET
       ),
-      height: getCalculatedHeight(headerHeight, itemHeight, maxRowCount),
+      height: getCalculatedHeight(headerHeight, itemHeight + padding, maxRowCount),
     },
   });
 

--- a/packages/hanging-garden/src/HangingGarden.tsx
+++ b/packages/hanging-garden/src/HangingGarden.tsx
@@ -29,6 +29,7 @@ import { makeStyles, createStyles } from '@equinor/fusion-react-styles';
  * @param provideController Returns a ref. this contains the renderGarden function. Used to trigger rerenders at will.
  * @param backgroundColor Backgroun color for the garden. Defaults to  white(0xffffff),
  * @param disableScrollToHighlightedItem Per default garden centers column of clicked item. This disables that interaction.
+ * @param padding Used to add padding to the packages and will also enable a different highlighted item border if above padding above 0. Defaults to 0.
  */
 
 const useStyles = makeStyles(() =>
@@ -62,6 +63,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   colorMode = 'Regular',
   disableScrollToHighlightedItem = false,
   groupLevels = 0,
+  padding = 0,
 }: HangingGardenProps<T>): JSX.Element {
   const [maxRowCount, setMaxRowCount] = useState(0);
   const [expandedColumns, setExpandedColumns] = useState<ExpandedColumns>({});
@@ -70,7 +72,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
   const canvas = useRef<HTMLCanvasElement>(null);
   const stage = useRef<PIXI.Container>(new PIXI.Container());
 
-  const scroll = useScrolling<T>(canvas, container, itemKeyProp, disableScrollToHighlightedItem);
+  const scroll = useScrolling<T>(canvas, container, itemKeyProp, padding, disableScrollToHighlightedItem);
   const textureCaches = useTextureCaches();
   const popover = usePopover();
 
@@ -112,6 +114,7 @@ function HangingGarden<T extends HangingGardenColumnIndex>({
             popover,
             colorMode,
             groupLevels,
+            padding,
           }}
         >
           <Garden<T> provideController={provideController} />

--- a/packages/hanging-garden/src/components/Vector2.ts
+++ b/packages/hanging-garden/src/components/Vector2.ts
@@ -1,0 +1,19 @@
+/**
+ * Helper class for calculating positions when drawing dashed lines
+ */
+class Vector2 {
+  x: number;
+  y: number;
+  constructor(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+  }
+
+  lerpVectors(v1: { x: number; y: number }, v2: { x: number; y: number }, alpha: number) {
+    this.x = v1.x + (v2.x - v1.x) * alpha;
+    this.y = v1.y + (v2.y - v1.y) * alpha;
+
+    return this;
+  }
+}
+export { Vector2 };

--- a/packages/hanging-garden/src/models/HangingGarden.ts
+++ b/packages/hanging-garden/src/models/HangingGarden.ts
@@ -37,4 +37,5 @@ export type HangingGardenProps<T extends HangingGardenColumnIndex> = {
   colorMode?: ColorMode;
   disableScrollToHighlightedItem?: boolean;
   groupLevels?: number;
+  padding?: number;
 };

--- a/packages/hanging-garden/src/renderHooks/useColumn.tsx
+++ b/packages/hanging-garden/src/renderHooks/useColumn.tsx
@@ -21,6 +21,7 @@ const useColumn = <T extends HangingGardenColumnIndex>(): UseColumn<T> => {
     container,
     itemHeight,
     expandedColumns,
+    padding,
   } = useHangingGardenContext();
 
   const { renderItem } = useRenderItem();
@@ -66,10 +67,10 @@ const useColumn = <T extends HangingGardenColumnIndex>(): UseColumn<T> => {
 
   const renderColumn = useCallback(
     (column: HangingGardenColumn<T>, index: number) => {
-      const startRow = Math.floor(scrollTop.current / itemHeight);
+      const startRow = Math.floor(scrollTop.current / (itemHeight + padding));
       const offSetHeight = container.current?.offsetHeight || 0;
 
-      const endRow = Math.min(column.data.length, Math.ceil((scrollTop.current + offSetHeight) / itemHeight));
+      const endRow = Math.min(column.data.length, Math.ceil((scrollTop.current + offSetHeight) / itemHeight + padding));
 
       isMultiGrouped(column.data)
         ? renderGroupedItems(column, startRow, index)
@@ -85,6 +86,7 @@ const useColumn = <T extends HangingGardenColumnIndex>(): UseColumn<T> => {
       container.current?.offsetHeight,
       scrollTop.current,
       itemHeight,
+      padding,
     ]
   );
 

--- a/packages/hanging-garden/src/renderHooks/useGarden.tsx
+++ b/packages/hanging-garden/src/renderHooks/useGarden.tsx
@@ -34,6 +34,7 @@ const useGarden = <T extends HangingGardenColumnIndex>(): UseGarden => {
     scroll: { scrollLeft, scrollTop, scrollToHighlightedColumn, scrollToHighlightedItem },
     textureCaches: { clearTextureCaches },
     groupLevels,
+    padding,
   } = useHangingGardenContext();
 
   const { renderColumn } = useColumn<T>();
@@ -70,8 +71,8 @@ const useGarden = <T extends HangingGardenColumnIndex>(): UseGarden => {
     const scrollRight = scrollLeft.current + offsetWidth + 10;
     for (let i = 0; i < (columns as HangingGardenColumn<T>[]).length; i++) {
       const column = (columns as HangingGardenColumn<T>[])[i];
-      const columnX = getColumnX(i, expandedColumns, itemWidth, groupLevels);
-      const width = getHeaderWidth(column.key, expandedColumns, itemWidth, groupLevels);
+      const columnX = getColumnX(i, expandedColumns, itemWidth + padding, groupLevels);
+      const width = getHeaderWidth(column.key, expandedColumns, itemWidth + padding, groupLevels);
 
       if (column && columnX + width >= scrollLeft.current && columnX <= scrollRight) renderColumn(column, i);
     }

--- a/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHangingGardenContext.tsx
@@ -33,6 +33,7 @@ export interface IHangingGardenContext {
   popover: UsePopover;
   colorMode: ColorMode;
   groupLevels: number;
+  padding: number;
 }
 
 const HangingGardenContext = createContext<IHangingGardenContext>({} as IHangingGardenContext);

--- a/packages/hanging-garden/src/renderHooks/useHeader.tsx
+++ b/packages/hanging-garden/src/renderHooks/useHeader.tsx
@@ -31,6 +31,7 @@ const useHeader = <T extends HangingGardenColumnIndex>(): UseHeader => {
     scroll: { scrollTop },
     textureCaches: { getTextureFromCache, addTextureToCache },
     groupLevels,
+    padding,
   } = useHangingGardenContext();
 
   const { getRenderedItemDescription } = useItemDescription<T>();
@@ -94,7 +95,7 @@ const useHeader = <T extends HangingGardenColumnIndex>(): UseHeader => {
         const headerWidth = getHeaderWidth(
           (columns as HangingGardenColumn<T>[])[index]?.key,
           expandedColumns,
-          itemWidth,
+          itemWidth + padding,
           groupLevels
         );
         const isHighlighted = highlightedColumnKey === key;
@@ -106,7 +107,7 @@ const useHeader = <T extends HangingGardenColumnIndex>(): UseHeader => {
         renderedHeader.on('tap', () => onHeaderClick(key, index));
 
         // Header container position and size
-        const x = getColumnX(index, expandedColumns, itemWidth, groupLevels);
+        const x = getColumnX(index, expandedColumns, itemWidth + padding, groupLevels);
         renderedHeader.x = x;
         renderedHeader.y = 0;
         renderedHeader.width = headerWidth;

--- a/packages/hanging-garden/src/renderHooks/useItem.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItem.tsx
@@ -37,6 +37,7 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
     popover: { addPopover },
     colorMode,
     groupLevels,
+    padding,
   } = useHangingGardenContext();
 
   const { createTextNode } = useTextNode();
@@ -72,8 +73,8 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
 
   const renderItem = useCallback(
     (item: T, index: number, columnIndex: number) => {
-      const x = getColumnX(columnIndex, expandedColumns, itemWidth, groupLevels);
-      const y = headerHeight + index * itemHeight;
+      const x = getColumnX(columnIndex, expandedColumns, itemWidth + padding, groupLevels);
+      const y = headerHeight + index * (itemHeight + padding);
 
       const key = `${item[itemKeyProp as keyof T]}_${colorMode}`;
       let renderedItem = getTextureFromCache('items', key) as PIXI.Container;
@@ -82,8 +83,8 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
         renderedItem = new PIXI.Container();
         renderedItem.x = x + GROUP_LEVEL_OFFSET * groupLevels;
         renderedItem.y = y;
-        renderedItem.width = itemWidth;
-        renderedItem.height = itemHeight;
+        renderedItem.width = itemWidth + padding;
+        renderedItem.height = itemHeight + padding;
         renderedItem.buttonMode = true;
         renderedItem.interactive = true;
         renderedItem.on('pointerdown', (e: PIXI.InteractionEvent) => {
@@ -126,8 +127,24 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
         if (!renderedHighlightedItem) {
           renderedHighlightedItem = new PIXI.Graphics();
           renderedHighlightedItem.cacheAsBitmap = true;
-          renderedHighlightedItem.lineStyle(4, 0x243746);
-          renderedHighlightedItem.drawRoundedRect(0, 0, itemWidth - 2, itemHeight - 2, 4);
+          if (padding <= 0) {
+            renderedHighlightedItem.lineStyle(4, 0x243746);
+            renderedHighlightedItem.drawRoundedRect(0, 0, itemWidth - 2, itemHeight - 2, 4);
+          } else {
+            const POS = 2;
+            renderedHighlightedItem.lineStyle(2, 0x007079);
+            renderedHighlightedItem.moveTo(-POS, -POS);
+
+            // @ts-ignore
+            renderedHighlightedItem.drawDashLine(itemWidth, -POS);
+            // @ts-ignore
+            renderedHighlightedItem.drawDashLine(itemWidth, itemHeight);
+            // @ts-ignore
+            renderedHighlightedItem.drawDashLine(-POS, itemHeight);
+
+            //@ts-ignore
+            renderedHighlightedItem.drawDashLine(-POS, -POS);
+          }
         }
 
         renderedHighlightedItem.x = x + GROUP_LEVEL_OFFSET * groupLevels;
@@ -160,6 +177,7 @@ const useItem = <T extends HangingGardenColumnIndex>(): UseItem<T> => {
       onItemClick,
       colorMode,
       groupLevels,
+      padding,
     ]
   );
 

--- a/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
+++ b/packages/hanging-garden/src/renderHooks/useItemDescription.tsx
@@ -32,6 +32,7 @@ const useItemDescription = <T extends HangingGardenColumnIndex>(): UseItemDescri
     getItemDescription,
     textureCaches: { getTextureFromCache, addTextureToCache },
     groupLevels,
+    padding,
   } = useHangingGardenContext();
 
   const { createTextNode } = useTextNode();
@@ -61,10 +62,12 @@ const useItemDescription = <T extends HangingGardenColumnIndex>(): UseItemDescri
       }
 
       const pixiContainer = getRenderedItemDescription(item);
-      pixiContainer.y = headerHeight + index * itemHeight + (itemHeight / 2 - pixiContainer.height / 2);
+      pixiContainer.y =
+        headerHeight + index * (itemHeight + padding) + ((itemHeight + padding) / 2 - pixiContainer.height / 2);
       pixiContainer.x =
-        getColumnX(columnIndex, expandedColumns, itemWidth, groupLevels) +
+        getColumnX(columnIndex, expandedColumns, itemWidth + padding, groupLevels) +
         itemWidth +
+        padding +
         groupLevels * GROUP_LEVEL_OFFSET +
         EXPANDED_COLUMN_PADDING;
       stage.current.removeChild(pixiContainer);

--- a/packages/hanging-garden/src/renderHooks/useRenderQueue.tsx
+++ b/packages/hanging-garden/src/renderHooks/useRenderQueue.tsx
@@ -19,6 +19,7 @@ const useRenderQueue = (): RenderQueue => {
   const {
     pixiApp,
     itemWidth,
+    padding,
     textureCaches: { getTextureFromCache, addTextureToCache },
   } = useHangingGardenContext();
 
@@ -60,7 +61,7 @@ const useRenderQueue = (): RenderQueue => {
     async (renderer: RenderItem) => {
       let graphicsContainer = getTextureFromCache('graphics', renderer.key) as PIXI.RenderTexture;
 
-      if (!graphicsContainer || graphicsContainer.width !== itemWidth) {
+      if (!graphicsContainer || graphicsContainer.width !== itemWidth + padding) {
         const graphics = new PIXI.Graphics();
         graphics.cacheAsBitmap = false;
         renderer.render({

--- a/packages/hanging-garden/src/renderHooks/useScrolling.tsx
+++ b/packages/hanging-garden/src/renderHooks/useScrolling.tsx
@@ -25,6 +25,7 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
   canvas: RefObject<HTMLCanvasElement> | null,
   container: RefObject<HTMLDivElement> | null,
   itemKeyProp: keyof T,
+  padding: number,
   disableScrollToHighlightedItem?: boolean
 ): Scroll<T> => {
   const isScrolling = useRef(false);
@@ -60,7 +61,9 @@ const useScrolling = <T extends HangingGardenColumnIndex>(
       const scrollWindowTo = Math.max(
         highlightedColumnIndex >= 0
           ? (container.current.scrollLeft =
-              highlightedColumnIndex * itemWidth - container.current.offsetWidth / 2 + itemWidth / 2)
+              highlightedColumnIndex * (itemWidth + padding) -
+              container.current.offsetWidth / 2 +
+              (itemWidth + padding) / 2)
           : 0,
         0
       );

--- a/packages/hanging-garden/src/utils.ts
+++ b/packages/hanging-garden/src/utils.ts
@@ -2,6 +2,7 @@ import * as PIXI from 'pixi.js-legacy';
 import { ColumnGroupHeader, HangingGardenColumn, HangingGardenColumnIndex } from './models/HangingGarden';
 import { ExpandedColumn, ExpandedColumns } from './models/ExpandedColumn';
 import { ItemRenderContext, Position } from './models/RenderContext';
+import { Vector2 } from './components/Vector2';
 
 export const DEFAULT_ITEM_HEIGHT = 24;
 export const DEFAULT_HEADER_HEIGHT = 32;
@@ -159,3 +160,29 @@ export const flattenColumn = <T extends HangingGardenColumnIndex>(
         []
       )
     : column.data;
+
+/**
+ * Method for drawing dashed lines
+ * @param toX x-coordinate you want to draw the dashed lines to
+ * @param toY y-coordinate you want to draw the dashed lines to
+ * @param dash length of the dashed lines
+ * @param gap the gap between the dashed lines
+ */
+//@ts-ignore
+PIXI.Graphics.prototype.drawDashLine = function (toX: number, toY: number, dash = 12, gap = 5) {
+  //@ts-ignore
+  const lastPosition = this.currentPath.points;
+  const from = new Vector2(lastPosition[lastPosition.length - 2] || 0, lastPosition[lastPosition.length - 1] || 0);
+  const to = new Vector2(toX, toY);
+  const a = from.x - to.x;
+  const b = from.y - to.y;
+  const distance = Math.sqrt(a * a + b * b);
+  const v = new Vector2();
+  for (let i = dash + gap; i <= distance; i += dash + gap) {
+    v.lerpVectors(from, to, (i - gap) / distance);
+    this.lineTo(v.x, v.y);
+    v.lerpVectors(from, to, i / distance);
+    this.moveTo(v.x, v.y);
+  }
+  this.lineTo(to.x, to.y);
+};


### PR DESCRIPTION
Can add padding around the packages by passing the `padding` prop. It will default to zero, and shouldn't have any impact on existing garden's if not passed as a prop. 
Adding padding will add a new dashed border around the package when highlighted.

Might have missed some dependency arrays with the new `padding` prop (?)