### PR TITLE
feat: pagination for table

### DIFF
--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/equinor/fusion-react-components/issues"
   },
   "dependencies": {
+    "@equinor/fusion-react-button": "^0.3.7",
     "@equinor/fusion-react-styles": "^0.3.5",
     "@equinor/fusion-wc-icon": "^1.0.12",
     "@equinor/fusion-wc-popover": "^1.0.13",

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -10,7 +10,41 @@ export type TableProps<TData extends TableData> = LayoutProps & {
   layout?: Layout<TData>;
   plugins?: Array<PluginHook<TData>>;
 };
-
+/**
+ * The main component for tabular display of data.
+ * Requires an array of columns and data passed as props.
+ * The component is very customizable and supports custom table layouts,
+ * table plugins, pagination, styling, filtering and sorting of columns.
+ * @param options - Table options such as columns, data, disablePagination, disableMenu.
+ * @param layout - A custom table layout. Defaults to the default table layout if not passed.
+ * @param plugins - Custom plugins added to the component.
+ * @param spacing - Spacing for the table layout.
+ * @param style - CSS style for the table layout.
+ * @param className - HTML attribute classname for the table layout.
+ * @example ```jsx
+ *     const columns: Column[] = [
+ *      {
+ *        Header: "First Name",
+ *        accessor: "firstName",
+ *        dataType: "string"
+ *      },
+ *      {
+ *        Header: "Last Name",
+ *        accessor: "firstName",
+ *        dataType: "string"
+ *      }
+ *    ];
+ *
+ *    const data = {
+ *        firstName: "James",
+ *        lastName: "Bond"
+ *    }
+ *
+ *  const MyApp = () => (
+ *    <Table options={{columns, data}} layout={VirtualLayout}/>
+ * )
+ * ```
+ */
 export const Table = <TData extends TableData>(props: PropsWithChildren<TableProps<TData>>): JSX.Element => {
   const { options, plugins: basePlugins = [], layout = TableLayout, children, ...layoutProps } = props;
   const { Template } = layout;

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -10,41 +10,7 @@ export type TableProps<TData extends TableData> = LayoutProps & {
   layout?: Layout<TData>;
   plugins?: Array<PluginHook<TData>>;
 };
-/**
- * The main component for tabular display of data.
- * Requires an array of columns and data passed as props.
- * The component is very customizable and supports custom table layouts,
- * table plugins, pagination, styling, filtering and sorting of columns.
- * @param options - Table options such as columns, data, disablePagination, disableMenu.
- * @param layout - A custom table layout. Defaults to the default table layout if not passed.
- * @param plugins - Custom plugins added to the component.
- * @param spacing - Spacing for the table layout.
- * @param style - CSS style for the table layout.
- * @param className - HTML attribute classname for the table layout.
- * @example ```jsx
- *     const columns: Column[] = [
- *      {
- *        Header: "First Name",
- *        accessor: "firstName",
- *        dataType: "string"
- *      },
- *      {
- *        Header: "Last Name",
- *        accessor: "firstName",
- *        dataType: "string"
- *      }
- *    ];
- *
- *    const data = {
- *        firstName: "James",
- *        lastName: "Bond"
- *    }
- *
- *  const MyApp = () => (
- *    <Table options={{columns, data}} layout={VirtualLayout}/>
- * )
- * ```
- */
+
 export const Table = <TData extends TableData>(props: PropsWithChildren<TableProps<TData>>): JSX.Element => {
   const { options, plugins: basePlugins = [], layout = TableLayout, children, ...layoutProps } = props;
   const { Template } = layout;

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -1,9 +1,9 @@
 import { TableOptions, PluginHook } from 'react-table';
 import { Layout, LayoutProps, TableLayout } from './layout';
-
 import { TableData } from './types';
 import { TableProvider } from './TableProvider';
 import { PropsWithChildren } from 'react';
+import Paginator from './components/pagination/Paginator';
 
 export type TableProps<TData extends TableData> = LayoutProps & {
   options: TableOptions<TData>;
@@ -20,6 +20,7 @@ export const Table = <TData extends TableData>(props: PropsWithChildren<TablePro
   return (
     <TableProvider options={options} plugins={plugins}>
       <Template {...layoutProps} />
+      <Paginator />
       {children}
     </TableProvider>
   );

--- a/packages/table/src/TableProvider.tsx
+++ b/packages/table/src/TableProvider.tsx
@@ -8,6 +8,7 @@ import {
   useSortBy,
   useTable,
   TableState,
+  usePagination,
 } from 'react-table';
 import { useDefaultColumn } from './components';
 import { useColumnMenu } from './plugins/menu';
@@ -34,7 +35,10 @@ export const TableProvider = <TData extends TableData = TableData>(
   const { children, options } = props;
 
   const _plugins = props.plugins || [];
-  const plugins = useMemo(() => [useResizeColumns, useColumnMenu, useFilters, useSortBy, ..._plugins], [..._plugins]);
+  const plugins = useMemo(
+    () => [useResizeColumns, useColumnMenu, useFilters, useSortBy, usePagination, ..._plugins],
+    [..._plugins]
+  );
 
   const defaultColumn = useDefaultColumn(options);
 

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnFirst.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnFirst.tsx
@@ -12,6 +12,7 @@ export const PaginationBtnFirst = (): JSX.Element => {
       variant="ghost"
       disabled={!canPreviousPage}
       color={canPreviousPage ? 'primary' : 'secondary'}
+      dense
     />
   );
 };

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnFirst.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnFirst.tsx
@@ -1,0 +1,18 @@
+import Button from '@equinor/fusion-react-button';
+import { useTableContext } from '../../../TableProvider';
+
+export const PaginationBtnFirst = (): JSX.Element => {
+  const { instance } = useTableContext();
+  const { gotoPage, canPreviousPage } = instance;
+
+  return (
+    <Button
+      onClick={() => gotoPage(0)}
+      icon="first_page"
+      variant="ghost"
+      disabled={!canPreviousPage}
+      color={canPreviousPage ? 'primary' : 'secondary'}
+    />
+  );
+};
+export default PaginationBtnFirst;

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnLast.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnLast.tsx
@@ -12,6 +12,7 @@ export const PaginationBtnLast = (): JSX.Element => {
       variant="ghost"
       disabled={!canNextPage}
       color={canNextPage ? 'primary' : 'secondary'}
+      dense
     />
   );
 };

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnLast.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnLast.tsx
@@ -1,0 +1,18 @@
+import Button from '@equinor/fusion-react-button';
+import { useTableContext } from '../../../TableProvider';
+
+export const PaginationBtnLast = (): JSX.Element => {
+  const { instance } = useTableContext();
+  const { gotoPage, pageCount, canNextPage } = instance;
+
+  return (
+    <Button
+      onClick={() => gotoPage(pageCount - 1)}
+      icon="last_page"
+      variant="ghost"
+      disabled={!canNextPage}
+      color={canNextPage ? 'primary' : 'secondary'}
+    />
+  );
+};
+export default PaginationBtnLast;

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnNext.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnNext.tsx
@@ -12,6 +12,7 @@ export const PaginationBtnNext = (): JSX.Element => {
       variant="ghost"
       disabled={!canNextPage}
       color={canNextPage ? 'primary' : 'secondary'}
+      dense
     />
   );
 };

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnNext.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnNext.tsx
@@ -1,0 +1,19 @@
+import Button from '@equinor/fusion-react-button';
+import { useTableContext } from '../../../TableProvider';
+
+export const PaginationBtnNext = (): JSX.Element => {
+  const { instance } = useTableContext();
+  const { nextPage, canNextPage } = instance;
+
+  return (
+    <Button
+      onClick={() => nextPage()}
+      icon="chevron_right"
+      variant="ghost"
+      disabled={!canNextPage}
+      color={canNextPage ? 'primary' : 'secondary'}
+    />
+  );
+};
+
+export default PaginationBtnNext;

--- a/packages/table/src/components/pagination/Buttons/PaginationBtnPrev.tsx
+++ b/packages/table/src/components/pagination/Buttons/PaginationBtnPrev.tsx
@@ -1,0 +1,18 @@
+import Button from '@equinor/fusion-react-button';
+import { useTableContext } from '../../../TableProvider';
+
+export const PaginationBtnPrev = (): JSX.Element => {
+  const { instance } = useTableContext();
+  const { previousPage, canPreviousPage } = instance;
+
+  return (
+    <Button
+      onClick={() => previousPage()}
+      icon="chevron_left"
+      variant="ghost"
+      disabled={!canPreviousPage}
+      color={canPreviousPage ? 'primary' : 'secondary'}
+      dense
+    />
+  );
+};

--- a/packages/table/src/components/pagination/Buttons/index.tsx
+++ b/packages/table/src/components/pagination/Buttons/index.tsx
@@ -1,0 +1,4 @@
+export { PaginationBtnFirst } from './PaginationBtnFirst';
+export { PaginationBtnNext } from './PaginationBtnNext';
+export { PaginationBtnPrev } from './PaginationBtnPrev';
+export { PaginationBtnLast } from './PaginationBtnLast';

--- a/packages/table/src/components/pagination/Paginator.style.ts
+++ b/packages/table/src/components/pagination/Paginator.style.ts
@@ -14,6 +14,12 @@ export const useStyles = makeStyles<FusionTheme, StyleProps>(
         justifyContent: 'end',
         alignItems: 'center',
       },
+      select: {
+        fontFamily: 'inherit',
+        margin: '0 1em 0 1em',
+        padding: '0 .5em 0 0',
+        fontSize: '14px',
+      },
     }),
   { name: 'fusion-table-pagination-layout' }
 );

--- a/packages/table/src/components/pagination/Paginator.style.ts
+++ b/packages/table/src/components/pagination/Paginator.style.ts
@@ -1,0 +1,21 @@
+import { makeStyles, FusionTheme, createStyles, theme } from '@equinor/fusion-react-styles';
+
+export type SpacingType = keyof typeof theme.spacing.comfortable;
+
+export type StyleProps = {
+  spacing: SpacingType;
+};
+
+export const useStyles = makeStyles<FusionTheme, StyleProps>(
+  () =>
+    createStyles({
+      pagination: {
+        display: 'flex',
+        justifyContent: 'end',
+        alignItems: 'center',
+      },
+    }),
+  { name: 'fusion-table-pagination-layout' }
+);
+
+export default useStyles;

--- a/packages/table/src/components/pagination/Paginator.tsx
+++ b/packages/table/src/components/pagination/Paginator.tsx
@@ -41,7 +41,7 @@ export const Paginator = (props: PaginatorProps): JSX.Element | null => {
       <div>Items per page: </div>
       {/*TODO: use fusion dropdown component */}
       <select
-        style={{ margin: '10px' }}
+        className={styles.select}
         value={pageSize}
         onChange={(e) => {
           setPageSize(Number(e.target.value));

--- a/packages/table/src/components/pagination/Paginator.tsx
+++ b/packages/table/src/components/pagination/Paginator.tsx
@@ -8,17 +8,29 @@ const defaultStyleProps: StyleProps = {
 type PaginatorProps = JSX.IntrinsicElements['div'];
 /**
  * Component for showing and controlling the pagination of the table component.
- * Returns null if the Table instance objects contains `disablePagination`.
- * @param props Styling props
+ * Returns null if `disablePagination` is set to `true`.
+ * Set the boolean in the `options` prop to the `Table` component to enable pagination.
+ * The `pageSize` is by default 10 (showing 10 records on each page), but can be changed.
+ * Same goes for `pageSizes`
+ * @param JSX.InstrinsicElements - HTML Attributes, e.g. styling.
+ * @example
+ * ```jsx
+ * const options = {
+ * data: data,
+ * columns: columns,
+ * disablePagination: false,
+ * pageSizes: [20,30,40],
+ * initialState: {
+ * pageSize: 20
+ *  },
+ * }
+ * return <Table options={options}/>
+ * ```
  */
 export const Paginator = (props: PaginatorProps): JSX.Element | null => {
-  const { instance } = useTableContext();
-  const {
-    pageOptions,
-    setPageSize,
-    disablePagination,
-    state: { pageIndex, pageSize },
-  } = instance;
+  const { instance, state } = useTableContext();
+  const { pageOptions, setPageSize, disablePagination = true, pageSizes = [10, 20, 30, 40, 50] } = instance;
+  const { pageIndex, pageSize } = state;
   const styles = useStyles({ ...defaultStyleProps });
 
   if (disablePagination) {
@@ -35,8 +47,7 @@ export const Paginator = (props: PaginatorProps): JSX.Element | null => {
           setPageSize(Number(e.target.value));
         }}
       >
-        {/*TODO: Make this array a prop, default to this? */}
-        {[10, 20, 30, 40, 50].map((pageSize) => (
+        {pageSizes.map((pageSize) => (
           <option key={pageSize} value={pageSize}>
             {pageSize}
           </option>

--- a/packages/table/src/components/pagination/Paginator.tsx
+++ b/packages/table/src/components/pagination/Paginator.tsx
@@ -1,0 +1,58 @@
+import { useTableContext } from '../../TableProvider';
+import { PaginationBtnFirst, PaginationBtnPrev, PaginationBtnNext, PaginationBtnLast } from './Buttons';
+import { StyleProps, useStyles } from './Paginator.style';
+
+const defaultStyleProps: StyleProps = {
+  spacing: 'small',
+};
+type PaginatorProps = JSX.IntrinsicElements['div'];
+/**
+ * Component for showing and controlling the pagination of the table component.
+ * Returns null if the Table instance objects contains `disablePagination`.
+ * @param props Styling props
+ */
+export const Paginator = (props: PaginatorProps): JSX.Element | null => {
+  const { instance } = useTableContext();
+  const {
+    pageOptions,
+    setPageSize,
+    disablePagination,
+    state: { pageIndex, pageSize },
+  } = instance;
+  const styles = useStyles({ ...defaultStyleProps });
+
+  if (disablePagination) {
+    return null;
+  }
+  return (
+    <div {...props} className={styles.pagination}>
+      <div>Items per page: </div>
+      {/*TODO: use fusion dropdown component */}
+      <select
+        style={{ margin: '10px' }}
+        value={pageSize}
+        onChange={(e) => {
+          setPageSize(Number(e.target.value));
+        }}
+      >
+        {/*TODO: Make this array a prop, default to this? */}
+        {[10, 20, 30, 40, 50].map((pageSize) => (
+          <option key={pageSize} value={pageSize}>
+            {pageSize}
+          </option>
+        ))}
+      </select>
+
+      <div>
+        {/*TODO: pageIndex should might not be undefined? See types.ts */}
+        {pageIndex !== undefined && `Page ${pageIndex + 1} of ${pageOptions.length}`}
+      </div>
+      <PaginationBtnFirst />
+      <PaginationBtnPrev />
+      <PaginationBtnNext />
+      <PaginationBtnLast />
+    </div>
+  );
+};
+
+export default Paginator;

--- a/packages/table/src/index.tsx
+++ b/packages/table/src/index.tsx
@@ -1,6 +1,5 @@
 export * from './useTable';
 export * from './components';
 export * from './types';
-
 export * from './Table';
 export * from './TableProvider';

--- a/packages/table/src/layout/TableLayout.tsx
+++ b/packages/table/src/layout/TableLayout.tsx
@@ -1,7 +1,5 @@
 import { clsx } from '@equinor/fusion-react-styles';
-
 import useStyles, { StyleProps } from './layout.style';
-
 import { Layout, LayoutProps } from './types';
 import { useTableContext } from '../TableProvider';
 // import { useFlexLayout } from 'react-table';
@@ -13,7 +11,8 @@ const defaultStyleProps: StyleProps = {
 export const TableLayoutTemplate = (props: LayoutProps): JSX.Element => {
   const { spacing = 'small', style, className } = props;
   const { instance } = useTableContext();
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = instance;
+  const { getTableProps, getTableBodyProps, headerGroups, prepareRow } = instance;
+  const rows = instance.disablePagination ? instance.rows : instance.page;
   const styles = useStyles({ ...defaultStyleProps, spacing });
   return (
     <table {...getTableProps({ className: clsx(styles.root, className) })} style={style}>

--- a/packages/table/src/types.ts
+++ b/packages/table/src/types.ts
@@ -51,6 +51,7 @@ declare module 'react-table' {
       TableData {
     disableMenu?: boolean;
     disablePagination?: boolean;
+    pageSizes?: number[];
     // readonly spacing?: SpacingType;
     // @ts-ignore
     // defaultColumn: Partial<FusionColumn<D>>;
@@ -82,6 +83,7 @@ declare module 'react-table' {
   // @ts-ignore
   export interface TableInstance<D extends TableData> extends UsePaginationInstanceProps<D> {
     disablePagination?: boolean;
+    pageSizes?: number[];
   }
 }
 

--- a/packages/table/src/types.ts
+++ b/packages/table/src/types.ts
@@ -50,6 +50,7 @@ declare module 'react-table' {
       // feature set, this is a safe default.
       TableData {
     disableMenu?: boolean;
+    disablePagination?: boolean;
     // readonly spacing?: SpacingType;
     // @ts-ignore
     // defaultColumn: Partial<FusionColumn<D>>;
@@ -74,9 +75,15 @@ declare module 'react-table' {
   export type PluginHook<TData extends TableData> = PluginHookDefault<TData>;
 
   // @ts-ignore
-  export interface TableState {
+  export interface TableState<TData extends TableData = TableData> extends Partial<UsePaginationState<TData>> {
     menu: MenuState;
+  }
+
+  // @ts-ignore
+  export interface TableInstance<D extends TableData> extends UsePaginationInstanceProps<D> {
+    disablePagination?: boolean;
   }
 }
 
+// @ts-ignore
 export { TableOptions, CellProps, SortByFn } from 'react-table';

--- a/packages/table/src/types.ts
+++ b/packages/table/src/types.ts
@@ -50,7 +50,9 @@ declare module 'react-table' {
       // feature set, this is a safe default.
       TableData {
     disableMenu?: boolean;
+    /* Set to false if the table will have pagination options. Defaults to true.*/
     disablePagination?: boolean;
+    /* The page size options the user can choose from when pagination is used. */
     pageSizes?: number[];
     // readonly spacing?: SpacingType;
     // @ts-ignore

--- a/packages/table/src/useTable.ts
+++ b/packages/table/src/useTable.ts
@@ -3,6 +3,7 @@ import {
   TableInstance,
   TableOptions,
   useFilters,
+  usePagination,
   useResizeColumns,
   useSortBy,
   useTable as useReactTable,
@@ -19,6 +20,7 @@ export const useTable = <TData extends TableData>(
   // TODO: check if sort is allready added?
   true && plugins.push(useFilters);
   true && plugins.push(useSortBy);
+  true && plugins.push(usePagination);
   true && plugins.push(useResizeColumns);
   true && plugins.push(useColumnMenu);
 

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -13,7 +13,10 @@
   ],
   "references": [
     {
-      "path": "../styles"
+      "path": "../styles",
+
+    }, {
+      "path": "../button"
     }
   ]
 }

--- a/storybook/src/stories/table/BasicTable.stories.tsx
+++ b/storybook/src/stories/table/BasicTable.stories.tsx
@@ -49,14 +49,13 @@ const Debugger = () => {
 };
 
 // TODO - generate data
-const Template = ({ rows, disablePagination }: { rows: number; disablePagination: boolean }) => {
+const Template = ({ rows }: { rows: number }) => {
   const options = useMemo(
     () => ({
       data: makeData(rows),
       columns,
-      disablePagination,
     }),
-    [rows, disablePagination]
+    [rows]
   );
   return (
     <Table options={options} style={{ minWidth: '100%' }}>
@@ -68,5 +67,4 @@ const Template = ({ rows, disablePagination }: { rows: number; disablePagination
 export const BasicTable = Template.bind({});
 BasicTable.args = {
   rows: 10,
-  disablePagination: true,
 };

--- a/storybook/src/stories/table/PaginationTable.stories.tsx
+++ b/storybook/src/stories/table/PaginationTable.stories.tsx
@@ -1,20 +1,7 @@
-import { Column, Table, useTableContext } from '@equinor/fusion-react-table';
+import { Column, Table, useTableContext, PaginationLayout } from '@equinor/fusion-react-table';
 import { Meta } from '@storybook/react';
 import { useMemo } from 'react';
 import makeData from './makeData';
-
-export default {
-  title: 'Table/Examples',
-  component: Table,
-  parameters: {
-    viewMode: 'docs',
-    previewTabs: {
-      canvas: { hidden: true },
-    },
-    chromatic: { disableSnapshot: false },
-  },
-} as Meta;
-
 const columns: Column[] = [
   {
     Header: 'First Name',
@@ -41,22 +28,24 @@ const columns: Column[] = [
     accessor: 'progress',
   },
 ];
-
 const Debugger = () => {
   const { instance } = useTableContext();
-
-  return <pre>{JSON.stringify(instance.state, null, 2)}</pre>;
+  const foo = {
+    canNextPage: instance.canNextPage,
+    canPreviousPage: instance.canPreviousPage,
+    ...instance.state,
+  };
+  return <pre>{JSON.stringify(foo, null, 2)}</pre>;
 };
 
-// TODO - generate data
-const Template = ({ rows, disablePagination }: { rows: number; disablePagination: boolean }) => {
+type StoryProps = { rows: number };
+export const PaginationTable = ({ rows = 50 }: StoryProps): React.ReactElement => {
   const options = useMemo(
     () => ({
       data: makeData(rows),
       columns,
-      disablePagination,
     }),
-    [rows, disablePagination]
+    [rows]
   );
   return (
     <Table options={options} style={{ minWidth: '100%' }}>
@@ -65,8 +54,14 @@ const Template = ({ rows, disablePagination }: { rows: number; disablePagination
   );
 };
 
-export const BasicTable = Template.bind({});
-BasicTable.args = {
-  rows: 10,
-  disablePagination: true,
-};
+export default {
+  title: 'Table/Examples/Pagination Table',
+  component: PaginationTable,
+  parameters: {
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+    chromatic: { disableSnapshot: false },
+  },
+} as Meta;

--- a/storybook/src/stories/table/PaginationTable.stories.tsx
+++ b/storybook/src/stories/table/PaginationTable.stories.tsx
@@ -1,4 +1,4 @@
-import { Column, Table, useTableContext, PaginationLayout } from '@equinor/fusion-react-table';
+import { Column, Table, useTableContext } from '@equinor/fusion-react-table';
 import { Meta } from '@storybook/react';
 import { useMemo } from 'react';
 import makeData from './makeData';
@@ -39,11 +39,16 @@ const Debugger = () => {
 };
 
 type StoryProps = { rows: number };
-export const PaginationTable = ({ rows = 50 }: StoryProps): React.ReactElement => {
+export const PaginationTable = ({ rows = 100 }: StoryProps): React.ReactElement => {
   const options = useMemo(
     () => ({
       data: makeData(rows),
       columns,
+      disablePagination: false,
+      pageSizes: [20, 30, 40],
+      initialState: {
+        pageSize: 20,
+      },
     }),
     [rows]
   );

--- a/storybook/src/stories/table/makeData.ts
+++ b/storybook/src/stories/table/makeData.ts
@@ -3,8 +3,8 @@ import namor from 'namor';
 const newPerson = () => {
   const statusChance = Math.random();
   return {
-    firstName: namor.generate({ words: 1, saltLength: 0 }),
-    lastName: namor.generate({ words: 1, saltLength: 0 }),
+    firstName: 'James',
+    lastName: 'Bond',
     age: Math.floor(Math.random() * 30),
     visits: Math.floor(Math.random() * 100),
     progress: Math.floor(Math.random() * 100),


### PR DESCRIPTION
# Pagination for Table component
Pagination will be turned __off by default__ , and 10 records will be shown by default.  
Pagination can be turned on by passing `disablePagination: false` property in the `options` prop of the Table component.
The amount of records shown by default can be changed by passing the `initialState: {pageSize: xx }` prop to `options` of `Table`.
The page sizes inside the select can be changed by passing the `pageSizes` prop. 