### PR TITLE
fix: error types for fetching garden data

### DIFF
--- a/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
+++ b/packages/hanging-garden/src/hooks/useHangingGardenGetData.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 
-import { GardenDataError } from '../models/GardenDataError';
+import { ApiErrorGardenResponse, GardenDataError } from '../models/GardenDataError';
 
 // TODO - @olerichard this should be removed from here, pass client as an provider
 import { HttpClientRequestFailedError, HttpResponse } from '@equinor/fusion/lib/http/HttpClient';
@@ -68,11 +68,10 @@ export const useHangingGardenGetData = <T,>(
           cacheDurationInMinutes: cacheDuration,
         };
       } catch (e) {
-        // TODO . @olerichard check if this typing is correct
-        const { response } = e as HttpClientRequestFailedError<GardenDataError>;
+        const { response } = e as HttpClientRequestFailedError<ApiErrorGardenResponse>;
         setError({
-          errorType: response.errorType || ' error',
-          errorResponse: response.errorResponse,
+          errorType: response.error.code || ' error',
+          errorResponse: response.error,
         });
         setIsFetching(false);
         return null;

--- a/packages/hanging-garden/src/models/GardenDataError.ts
+++ b/packages/hanging-garden/src/models/GardenDataError.ts
@@ -20,3 +20,9 @@ export type GardenDataError = {
   errorType: GardenDataErrorTypes;
   errorResponse?: FusionApiErrorMessage | null;
 };
+
+export type ApiErrorGardenResponse = {
+  error: FusionApiErrorMessage & {
+    code: GardenDataErrorTypes;
+  };
+};


### PR DESCRIPTION
The specified error type in the code does not match with the actual error object from the api causing the app to not show the correct error message.
example error response from the api: 
```json
{
    "error": {
        "code": "NoDataAccess",
        "message": "You do not have access to any of the projects resolved for the context:....",
        "accessRequirements": [
          {...},
        ],
    }
}
```

Does not match with
```ts
export type GardenDataError = {
  errorType: GardenDataErrorTypes;
  errorResponse?: FusionApiErrorMessage | null;
};
 type FusionApiErrorMessage = {
    code: string;
    message: string;
    errors: FusionApiModelBindingError[];
};

 const { response } = e as HttpClientRequestFailedError<GardenDataError>;
      setError({
          errorType: response.errorType || ' error',
          errorResponse: response.errorResponse,
        });
```

Fixed with creating new type that matches the api error response object
```ts
export type ApiErrorGardenResponse = {
  error: FusionApiErrorMessage & {
    code: GardenDataErrorTypes;
  };
};
```
Still using `FusionApiErrorMessage` even though some properties  don't match with the error response from the api, but don't wanna change a lot of code