### PR TITLE
fix: Hanging Garden - ScrollTo ExpandedColumns offset 

### DIFF
--- a/packages/hanging-garden/src/renderHooks/useGarden.tsx
+++ b/packages/hanging-garden/src/renderHooks/useGarden.tsx
@@ -43,7 +43,12 @@ const useGarden = <T extends HangingGardenColumnIndex>(): UseGarden => {
     clearTextureCaches();
     setExpandedColumns({});
     setMaxRowCount(getMaxRowCount(columns as HangingGardenColumn<T>[]));
-    scrollToHighlightedColumn(columns as HangingGardenColumn<T>[], highlightedColumnKey as string, itemWidth);
+    scrollToHighlightedColumn(
+      columns as HangingGardenColumn<T>[],
+      highlightedColumnKey as string,
+      itemWidth,
+      expandedColumns
+    );
     renderGarden();
   }, [columns]);
 
@@ -53,7 +58,7 @@ const useGarden = <T extends HangingGardenColumnIndex>(): UseGarden => {
   }, [expandedColumns]);
 
   useEffect(() => {
-    if (scrollToHighlightedItem(columns as HangingGardenColumn<T>[], highlightedItem, itemWidth)) {
+    if (scrollToHighlightedItem(columns as HangingGardenColumn<T>[], highlightedItem, itemWidth, expandedColumns)) {
       clearTextureCaches();
       renderGarden();
     }


### PR DESCRIPTION
useScrolling functions now can take in a object of expandedColumns.
These will be passed down to the ScrollTo function.
Which again uses it to calculate the an offset based on expanded column when trying to center a column.
If trying to center a columns and there was expanded columns to the right of its index.
the base itemWidth was till used for expanded columns, making the column end up offcenter.
This accounts new expandedColumnsOffset calculates this offset and adds it to the scrollWIndowTo calculation.