### PR TITLE
[DatePicker]: update styling for datepicker input

### DIFF
--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -21,7 +21,7 @@ type InputProps = {
 };
 
 const defaultStyleProps: StyleProps = {
-  spacing: 'medium',
+  spacing: 'small',
 };
 
 const useStyles = makeStyles(

--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, InputHTMLAttributes, useCallback } from 'react';
-import { makeStyles, createStyles, theme } from '@equinor/fusion-react-styles';
+import { makeStyles, createStyles, theme, clsx } from '@equinor/fusion-react-styles';
 import Icon from './Icon';
 import { calendar, clear, time } from '@equinor/eds-icons';
 import { FusionDatePickerType } from '../types';
@@ -27,24 +27,33 @@ const defaultStyleProps: StyleProps = {
 const useStyles = makeStyles(
   (theme) =>
     createStyles({
+      '@keyframes rippling': {
+        '0%': {
+          transform: 'scale(0)',
+        },
+        '100%': {
+          transform: 'scale(1)',
+        },
+      },
       container: ({ spacing, disabled }: StyleProps) => ({
         ...theme.spacing.comfortable[spacing].style,
         display: 'flex',
         backgroundColor: theme.colors.ui.background__light.value.hex,
         boxShadow: disabled ? 'none' : `0px -1px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,
-        '&:focus-within': {
-          boxShadow: `0px -2px 0px 0px inset ${theme.colors.interactive.focus.value.hex}`,
-        },
         justifyContent: 'center',
         alignItems: 'center',
         borderRadius: '0.5em 0.5em 0 0',
         '&:hover': {
           backgroundColor: theme.colors.ui.background__medium.value.hex,
         },
-        transition: 'box-shadow 0.5s ease-out',
       }),
       error: {
         color: 'red',
+      },
+      ripple: {
+        width: '100%',
+        position: 'absolute',
+        bottom: 0,
       },
       input: ({ hasValue, isError }: StyleProps) => ({
         ...theme.typography.input.text.style,
@@ -56,13 +65,20 @@ const useStyles = makeStyles(
         border: 'none',
         background: 'none',
         width: '100%',
-        '&:focus': {
-          outline: `none`,
-        },
         '&:disabled': {
           color: theme.colors.interactive.disabled__text.value.hex,
         },
       }),
+      inputFocus: {
+        '&:focus': {
+          outline: 'none',
+          '& ~ $ripple': {
+            animation: '$rippling .3s',
+            backgroundColor: theme.colors.interactive.focus.value.hex,
+            height: '2px',
+          },
+        },
+      },
       icon: {
         ...theme.typography.navigation.menu_title.style,
         color: theme.colors.text.static_icons__tertiary.value.hex,
@@ -105,9 +121,10 @@ export const FusionDatePickerInput = forwardRef<HTMLInputElement, InputHTMLAttri
           placeholder={placeholder}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className={classes.input}
+          className={clsx(classes.input, classes.inputFocus)}
           ref={ref}
         />
+        <span className={classes.ripple} />
         {isClearable && props.value ? (
           <Icon
             icon={clear}

--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles(
       },
       container: ({ spacing, disabled }: StyleProps) => ({
         ...theme.spacing.comfortable[spacing].style,
+        height: '40px',
         display: 'flex',
         backgroundColor: theme.colors.ui.background__light.value.hex,
         boxShadow: disabled ? 'none' : `0px -1px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,

--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -3,7 +3,6 @@ import { makeStyles, createStyles, theme, clsx } from '@equinor/fusion-react-sty
 import Icon from './Icon';
 import { calendar, clear, time } from '@equinor/eds-icons';
 import { FusionDatePickerType } from '../types';
-
 type SpacingType = keyof typeof theme.spacing.comfortable;
 
 type StyleProps = {
@@ -40,10 +39,10 @@ const useStyles = makeStyles(
         height: '40px',
         display: 'flex',
         backgroundColor: theme.colors.ui.background__light.value.hex,
-        boxShadow: disabled ? 'none' : `0px -1px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,
+        boxShadow: disabled ? 'none' : `0px -0.5px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,
         justifyContent: 'center',
         alignItems: 'center',
-        borderRadius: '0.5em 0.5em 0 0',
+        borderRadius: '4px 4px 0 0',
         '&:hover': {
           backgroundColor: theme.colors.ui.background__medium.value.hex,
         },

--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes, useCallback } from 'react';
 import { makeStyles, createStyles, theme } from '@equinor/fusion-react-styles';
 import Icon from './Icon';
 import { calendar, clear, time } from '@equinor/eds-icons';
@@ -21,7 +21,7 @@ type InputProps = {
 };
 
 const defaultStyleProps: StyleProps = {
-  spacing: 'small',
+  spacing: 'medium',
 };
 
 const useStyles = makeStyles(
@@ -29,15 +29,19 @@ const useStyles = makeStyles(
     createStyles({
       container: ({ spacing, disabled }: StyleProps) => ({
         ...theme.spacing.comfortable[spacing].style,
-        backgroundColor: theme.colors.ui.background__light.value.hex,
-        borderBottom: disabled ? 'none' : `1px solid ${theme.colors.text.static_icons__tertiary.value.hex}`,
-        '&:focus-within': {
-          outline: `2px solid ${theme.colors.interactive.focus.value.hex}`,
-          borderBottom: '1px solid transparent',
-        },
         display: 'flex',
+        backgroundColor: theme.colors.ui.background__light.value.hex,
+        boxShadow: disabled ? 'none' : `0px -1px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,
+        '&:focus-within': {
+          boxShadow: `0px -2px 0px 0px inset ${theme.colors.interactive.focus.value.hex}`,
+        },
         justifyContent: 'center',
         alignItems: 'center',
+        borderRadius: '0.5em 0.5em 0 0',
+        '&:hover': {
+          backgroundColor: theme.colors.ui.background__medium.value.hex,
+        },
+        transition: 'box-shadow 0.5s ease-out',
       }),
       error: {
         color: 'red',
@@ -73,23 +77,34 @@ const useStyles = makeStyles(
 
 export const FusionDatePickerInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement> & InputProps>(
   (props: InputHTMLAttributes<HTMLInputElement> & InputProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const { dateFormat, isClearable, onClear, placeholder, type, ...rest } = props;
-
+    const { dateFormat, isClearable, onClear, placeholder, type, onFocus, onBlur, ...rest } = props;
     const classes = useStyles({
       ...defaultStyleProps,
       disabled: props.disabled,
       hasValue: props.value ? true : false,
     });
+    const handleBlur = useCallback(
+      (e: React.FocusEvent<HTMLInputElement>) => {
+        onBlur && onBlur(e);
+        e.target.placeholder = placeholder ?? '';
+      },
+      [placeholder, onBlur]
+    );
+    const handleFocus = useCallback(
+      (e: React.FocusEvent<HTMLInputElement>) => {
+        onFocus && onFocus(e);
+        e.target.placeholder = dateFormat;
+      },
+      [dateFormat, onFocus]
+    );
 
     return (
       <div className={classes.container}>
         <input
           {...rest}
           placeholder={placeholder}
-          onFocus={(e) => (e.target.placeholder = dateFormat)}
-          onBlur={(e) => {
-            e.target.placeholder = placeholder ?? '';
-          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           className={classes.input}
           ref={ref}
         />


### PR DESCRIPTION
Updated styling so it looks more like our TextInput component. Couldn't use TextInput component because of types that are not compatible. Also included the `onFocus` and `onBlur` methods, fixes the issue with when you're typing and it autocompletes. 

Continuation of PR #152
