### PR TITLE
fix(style): fix space-between icons

### DIFF
--- a/packages/datepicker/src/components/DatePickerInput.tsx
+++ b/packages/datepicker/src/components/DatePickerInput.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(
         display: 'flex',
         backgroundColor: theme.colors.ui.background__light.value.hex,
         boxShadow: disabled ? 'none' : `0px -0.5px 0px 0px inset ${theme.colors.text.static_icons__tertiary.value.hex}`,
-        justifyContent: 'center',
+        justifyContent: 'space-between',
         alignItems: 'center',
         borderRadius: '4px 4px 0 0',
         '&:hover': {


### PR DESCRIPTION
Fix space-between the icons in datepicker.
![image](https://user-images.githubusercontent.com/56077030/148177372-28f23dd4-2498-4e0b-a198-f5a45b0f2730.png)
