### PR TITLE
fix: ag-grid-utils, show only status for non-group rows

### DIFF
--- a/packages/ag-grid-utils/src/changeHandlerUtils/StatusComponent.tsx
+++ b/packages/ag-grid-utils/src/changeHandlerUtils/StatusComponent.tsx
@@ -31,6 +31,9 @@ const useStyles = makeStyles(
 const StatusComponent: FC<ICellRendererParams> = (props) => {
   const styles = useStyles();
 
+  const isGroupRow = props.node.group;
+  if (isGroupRow) return null;
+
   return props.data?.hasChanged || props.data?.status === AGGridDataStatus.NEW ? (
     <div className={styles.statusContainer}>
       <div className={styles.pendingChanges} />


### PR DESCRIPTION
# Component Development

<!-- use the imperative, present tense: "change" not "changed" nor "changes" -->

<!-- Keep descriptions short and precise, if large pull request expand with work/bug items-->

### Type

- [ ] Feature
- [x] Fix
- [ ] Hotfix (should release ASAP)
- [ ] Maintenance (deps only)

### Reference to assignment

<!-- Link to  work/bug items in Azure Devops or related issue in Github -->


### Description of assignment

<!-- Explain what this pull request is trying to resolve -->
The status column component for the ag-grid-utils package shows status indication for each row no matter what.
This fix removes the status indication for row groups columns
  
### Description of Proposed Changes

<!-- Describe which functionality is added/changed and what it affects -->



## Checklist
  

#### Create User Story(DevOps) or Issue(Github)

- [ ] Describe functional requirements
- [ ] Design plan/suggestion (e.g. images, link to eds design or relevant figma links, mention of eds tokens to use)
- [ ] Communication with UX *(evaluate if needed)*

#### Development

- [ ] Describe the component
- [ ] Code funtional requirements
- [ ] Create stories
- [ ] Create snapshots *(evaluate if needed)*
- [ ] Remove unused imports and commented code
- [ ] Lint code with EsLint (and follow best practises for [code quality](https://docs.fusion-dev.net/development/frontend/code-quality/)
  
#### Create Pull Request

- [ ] Assign relevant reviewers in Github and Cromatic
- [ ] Inform colleagues of pending reviews. We use Teams for this purpose, under fusion-frontend team please tag involved reviewers in the [Code review channel](https://teams.microsoft.com/l/channel/19%3a056a9ba8d8d84a058b24762f85c603ae%40thread.tacv2/Code%2520%2520review?groupId=9589ba16-68a5-47e6-97d7-7d0be0e0d3cb&tenantId=3aa4a235-b6e2-48d5-9195-7fcf05b459b0)

#### Review of Pull Request

- [ ] Follow up on comments from code review and implement necessary changes *(evaluate if needed)*
- [ ] Review approved in github (and chromatic)

#### Publish Code

- [ ] Increment version number
- [ ] Merge PR
- [ ] Consider letting fusion developers know this this shiny new thing exists
