### PR TITLE
fix(agGrid-styles): font-family

### DIFF
--- a/packages/ag-grid-styles/src/agGridStyles/styles.jss.json
+++ b/packages/ag-grid-styles/src/agGridStyles/styles.jss.json
@@ -1,7 +1,7 @@
 {
   "@global": {
     ".ag-icon": {
-      "font-family": "var(--ag-icon-font-family)",
+      "font-family": "var(--ag-icon-font-family) !important",
       "font-size": "var(--ag-icon-size)",
       "line-height": "var(--ag-icon-size)",
       "font-style": "normal",


### PR DESCRIPTION
# Component Development
## AGgrid Styles
<!-- use the imperative, present tense: "change" not "changed" nor "changes" -->

<!-- Keep descriptions short and precise, if large pull request expand with work/bug items-->

### Type

- [ ] Feature
- [ ] Fix
- [x] Hotfix (should release ASAP)
- [ ] Maintenance (deps only)

### Reference to assignment
[[ContractPersonnel] Table icons aren't loading](https://statoil-proview.visualstudio.com/Fusion/_workitems/edit/43212/)
<!-- Link to  work/bug items in Azure Devops or related issue in Github -->


### Description of assignment
Added `!important` to `.ag-icon` class, since portal overrides font family of AGgrid
<!-- Explain what this pull request is trying to resolve -->
