### PR TITLE
fix(context-selector): remove react-icon

### DIFF
--- a/.changeset/brown-rockets-chew.md
+++ b/.changeset/brown-rockets-chew.md
@@ -1,0 +1,16 @@
+---
+"@equinor/fusion-react-context-selector": patch
+---
+
+- In packages/context-selector/package.json:
+  - Replaces dependency `@equinor/fusion-react-icon` with `@equinor/fusion-wc-icon`
+  - Updates the dependency:
+    - @equinor/fusion-wc-searchable-dropdown to version ^3.6.0
+  - Removes a dependency:
+    - @equinor/fusion-react-icon
+  - Adds a peer dependency:
+    - @types/react version ^18
+    - react version ^18
+  - Defines @types/react as an optional peer dependency
+- In packages/context-selector/src/ContextSearch.tsx:
+  - Updates the code to use fwc-icon instead of Icon component

--- a/packages/context-selector/package.json
+++ b/packages/context-selector/package.json
@@ -37,14 +37,23 @@
     "url": "https://github.com/equinor/fusion-react-components/issues"
   },
   "dependencies": {
-    "@equinor/fusion-react-icon": "workspace:^",
     "@equinor/fusion-react-searchable-dropdown": "workspace:^",
     "@equinor/fusion-react-styles": "workspace:^",
     "@equinor/fusion-react-utils": "workspace:^",
+    "@equinor/fusion-wc-icon": "^2.3.0",
     "@equinor/fusion-wc-searchable-dropdown": "^3.6.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.24",
     "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^18",
+    "react": "^18"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/context-selector/src/ContextSearch.tsx
+++ b/packages/context-selector/src/ContextSearch.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Icon } from '@equinor/fusion-react-icon';
 import { clsx } from '@equinor/fusion-react-styles';
 import { ContextSelector } from './ContextSelector';
 import { ContextSelectorProps, ContextResultItem, ContextSelectEvent } from './types';
 import { useStyles } from './ContextSearch.styles';
 import { SearchableDropdownElement } from '@equinor/fusion-wc-searchable-dropdown';
+
+import { IconElement } from '@equinor/fusion-wc-icon';
+IconElement;
 
 export type ContextSearchProps = ContextSelectorProps & {
   previewItem?: ContextResultItem;
@@ -153,7 +155,7 @@ export const ContextSearch = ({
       <div className={clsx(gettingCtx && styles.hidden)}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/no-static-element-interactions */}
         <div className={styles.context} onKeyUp={() => handleKeyup}>
-          <div className={styles.icon}>{ctx?.graphic && <Icon icon={ctx.graphic} />}</div>
+          <div className={styles.icon}>{ctx?.graphic && <fwc-icon icon={ctx.graphic}></fwc-icon>}</div>
           {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
           <div tabIndex={0} className={styles.titleBlock} onClick={toggleGettingCtx} onKeyDown={keyUpGettingCtx}>
             <span className={styles.title}>{ctx?.title}</span>
@@ -162,7 +164,7 @@ export const ContextSearch = ({
           <div className={styles.icon}>
             {ctx && !ctx.isDisabled && (
               <button className={clsx(styles.closeBtn)} onClick={handleClearContext}>
-                <Icon icon="close" />
+                <fwc-icon icon="close"></fwc-icon>
               </button>
             )}
           </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
 
   packages/context-selector:
     dependencies:
-      '@equinor/fusion-react-icon':
-        specifier: workspace:^
-        version: link:../icon
       '@equinor/fusion-react-searchable-dropdown':
         specifier: workspace:^
         version: link:../searchable-dropdown
@@ -184,6 +181,9 @@ importers:
       '@equinor/fusion-react-utils':
         specifier: workspace:^
         version: link:../utils
+      '@equinor/fusion-wc-icon':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@equinor/fusion-wc-searchable-dropdown':
         specifier: ^3.6.0
         version: 3.6.0


### PR DESCRIPTION
## prepare for deprecation of `@equinor/fusion-react-icon`

- In packages/context-selector/package.json:
  - Replaces dependency `@equinor/fusion-react-icon` with `@equinor/fusion-wc-icon`
  - Updates the dependency:
    - @equinor/fusion-wc-searchable-dropdown to version ^3.6.0
  - Removes a dependency:
    - @equinor/fusion-react-icon
  - Adds a peer dependency:
    - @types/react version ^18
    - react version ^18
  - Defines @types/react as an optional peer dependency
- In packages/context-selector/src/ContextSearch.tsx:
  - Updates the code to use fwc-icon instead of Icon component
