### PR TITLE
fix(deps): reverting update of @equinor/eds-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,3 @@
 this repo is only for custom components used in Fusion, please check [EDS](https://eds.equinor.com/0b0c666ab/p/238bf3-equinor-design-system) before using any components
 
 ## [Storybook](https://equinor.github.io/fusion-react-components?path=/docs/intro--page/)
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@equinor/fusion-react-components",
   "version": "1.1.0",
   "private": true,
-  "description": "collection of fusion components",
+  "description": "monorepo of fusion react components",
   "main": "index.js",
   "engines": {
     "node": "^16 || ^18 || ^20",

--- a/packages/ag-grid-styles/src/agGridStyles/styles.jss.json
+++ b/packages/ag-grid-styles/src/agGridStyles/styles.jss.json
@@ -1728,7 +1728,7 @@
       "position": "relative",
       "overflow": "hidden",
       "cursor": "default",
-      "background-color": "rgb(255, 0, 0)",
+      "background-color": "red",
       "border-radius": "2px"
     },
     ".ag-spectrum-fill": {
@@ -1766,7 +1766,7 @@
       "border-radius": "2px"
     },
     ".ag-spectrum-alpha-background": {
-      "background-image": "linear-gradient(to right, rgba(0, 0, 0, 0), rgb(0, 0, 0))",
+      "background-image": "linear-gradient(to right, rgba(0, 0, 0, 0), black)",
       "width": "100%",
       "height": "100%",
       "border-radius": "2px"
@@ -1784,7 +1784,7 @@
       "width": "13px",
       "height": "13px",
       "border-radius": "13px",
-      "background-color": "rgb(248, 248, 248)",
+      "background-color": "#f8f8f8",
       "box-shadow": "0 1px 4px 0 rgba(0, 0, 0, 0.37)"
     },
     ".ag-recent-colors": {

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -44,7 +44,7 @@
     "@equinor/fusion-react-styles": "^0.6.0",
     "@equinor/fusion-react-utils": "^2.1.0",
     "@equinor/fusion-wc-chip": "^1.1.0",
-    "rxjs": "^7.4.0",
+    "rxjs": "^7.8.1",
     "typesafe-actions": "^5.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
         specifier: ^1.1.0
         version: 1.2.0
       rxjs:
-        specifier: ^7.4.0
+        specifier: ^7.8.1
         version: 7.8.1
       typesafe-actions:
         specifier: ^5.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11415,7 +11415,6 @@ packages:
 
   /figgy-pudding@3.5.2:
     resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
-    deprecated: This module is no longer supported.
     dev: false
 
   /figures@3.2.0:


### PR DESCRIPTION
# Component Development

@equinor/eds-icons@0.2.0 returned wrong Icon type so you could no longer register the imported icons.
Realign eds-core-react so all packages use the same version, 0.34.0.
Realign rxjs so all packages use the same version, 7.8.1.

<!-- use the imperative, present tense: "change" not "changed" nor "changes" -->

<!-- Keep descriptions short and precise, if large pull request expand with work/bug items-->

### Type

- [ ] Feature
- [x] Fix
- [x] Hotfix (should release ASAP)
- [x] Maintenance (deps only)
