### PR TITLE
fix(context-selector): removing react as peerdep

### DIFF
--- a/.changeset/curly-bags-fly.md
+++ b/.changeset/curly-bags-fly.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-react-context-selector": patch
+---
+
+Removes react as peer dependencie

--- a/packages/context-selector/package.json
+++ b/packages/context-selector/package.json
@@ -46,14 +46,5 @@
   "devDependencies": {
     "@types/react": "^18.2.24",
     "react": "^18.2.0"
-  },
-  "peerDependencies": {
-    "@types/react": "^18",
-    "react": "^18"
-  },
-  "peerDependenciesMeta": {
-    "@types/react": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
# Component Development

Remove react and @types/react as peer dependencies as its only used as dev dependencies.
Having them as peer on version 18 creates peerdep conflicts in react 17 apps.

<!-- use the imperative, present tense: "change" not "changed" nor "changes" -->

<!-- Keep descriptions short and precise, if large pull request expand with work/bug items-->

### Type

- [ ] Feature
- [x] Fix
- [ ] Hotfix (should release ASAP)
- [x] Maintenance (deps only)

### Reference to assignment

<!-- Link to  work/bug items in Azure Devops or related issue in Github -->


### Description of assignment

<!-- Explain what this pull request is trying to resolve -->

  
### Description of Proposed Changes

<!-- Describe which functionality is added/changed and what it affects -->



## Checklist
  

#### Create User Story(DevOps) or Issue(Github)

- [ ] Describe functional requirements
- [ ] Design plan/suggestion (e.g. images, link to eds design or relevant figma links, mention of eds tokens to use)
- [ ] Communication with UX *(evaluate if needed)*

#### Development

- [ ] Describe the component
- [ ] Code funtional requirements
- [ ] Create stories
- [ ] Create snapshots *(evaluate if needed)*
- [ ] Remove unused imports and commented code
- [ ] Lint code with EsLint (and follow best practises for [code quality](https://docs.fusion-dev.net/development/frontend/code-quality/)
  
#### Create Pull Request

- [ ] Assign relevant reviewers in Github and Cromatic
- [ ] Inform colleagues of pending reviews. We use Teams for this purpose, under fusion-frontend team please tag involved reviewers in the [Code review channel](https://teams.microsoft.com/l/channel/19%3a056a9ba8d8d84a058b24762f85c603ae%40thread.tacv2/Code%2520%2520review?groupId=9589ba16-68a5-47e6-97d7-7d0be0e0d3cb&tenantId=3aa4a235-b6e2-48d5-9195-7fcf05b459b0)

#### Review of Pull Request

- [ ] Follow up on comments from code review and implement necessary changes *(evaluate if needed)*
- [ ] Review approved in github (and chromatic)

#### Publish Code

- [ ] Increment version number
- [ ] Merge PR
- [ ] Consider letting fusion developers know this this shiny new thing exists
