### PR TITLE
Fix/context selector/clear context externally

### DIFF
--- a/.changeset/tough-pots-wash.md
+++ b/.changeset/tough-pots-wash.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-react-context-selector': patch
+---
+
+Fixes clearing context exernally when using previewItem to display currentContext

--- a/.changeset/tough-pots-wash.md
+++ b/.changeset/tough-pots-wash.md
@@ -2,4 +2,4 @@
 '@equinor/fusion-react-context-selector': patch
 ---
 
-Fixes clearing context exernally when using previewItem to display currentContext
+Adds event `ctx-selector-clear` to be able to clear the context-selectors state from outside the component.

--- a/packages/context-selector/src/ContextSearch.tsx
+++ b/packages/context-selector/src/ContextSearch.tsx
@@ -8,6 +8,21 @@ import { SearchableDropdownElement } from '@equinor/fusion-wc-searchable-dropdow
 import { IconElement } from '@equinor/fusion-wc-icon';
 IconElement;
 
+const ContextClearEventType = 'ctx-selector-clear';
+interface ContextClearEventDetails {
+  date?: number;
+}
+export class ContextClearEvent extends CustomEvent<ContextClearEventDetails> {
+  static readonly eventName = ContextClearEventType;
+  constructor(options: ContextClearEventDetails) {
+    super(ContextClearEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      detail: options,
+    });
+  }
+}
+
 export type ContextSearchProps = ContextSelectorProps & {
   previewItem?: ContextResultItem;
   onClearContext?: (e: Event) => void;
@@ -143,6 +158,18 @@ export const ContextSearch = ({
       }
     };
   }, [elementRef]);
+
+  /**
+   * Add ctx-selector-clear event listener.
+   * Used when triggering clear context outside component
+   */
+  useMemo(() => {
+    const clearContextHandler = () => setCtx(defaultInitialItem);
+    document.addEventListener(ContextClearEventType, clearContextHandler);
+    return () => {
+      document.removeEventListener(ContextClearEventType, clearContextHandler);
+    };
+  }, []);
 
   useEffect(() => {
     if (sdd && gettingCtx) {

--- a/packages/context-selector/src/index.tsx
+++ b/packages/context-selector/src/index.tsx
@@ -1,6 +1,6 @@
 export { ContextProvider } from './ContextProvider';
 export { ContextSelector } from './ContextSelector';
-export { ContextSearch, type ContextSearchProps } from './ContextSearch';
+export { ContextSearch, type ContextSearchProps, ContextClearEvent } from './ContextSearch';
 export type {
   ContextProviderProps,
   ContextResolver,


### PR DESCRIPTION
# Component Development

**Context-Selector**

Adds event `ctx-selector-clear` to be able to clear the context-selectors state from outside the component.

This can be useful when clearing the context from fusion-framework.

### Type

- [ ] Feature
- [x] Fix
- [ ] Hotfix (should release ASAP)
- [ ] Maintenance (deps only)
