### PR TITLE
Fix typing in create-element function

### DIFF
--- a/.changeset/four-cloths-behave.md
+++ b/.changeset/four-cloths-behave.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-react-utils': patch
+---
+
+fix typing in `create-element`

--- a/packages/utils/src/create-element.ts
+++ b/packages/utils/src/create-element.ts
@@ -52,7 +52,6 @@ export const createComponent = <E extends HTMLElement, P extends Record<string, 
     displayName?: string;
   } = {},
 ): WebComponent<E, P> => {
-  type ComponentProps = PropsWithoutRef<ComponentAttributes<E> & P>;
   type EventProps = Partial<Record<keyof E, EventHandler<SyntheticEvent<E, Event>>>>;
 
   const { events = {}, functions = new Set(), displayName = elementClass.name } = options;
@@ -66,9 +65,8 @@ export const createComponent = <E extends HTMLElement, P extends Record<string, 
   /** element native props which should be handled programmatically */
   const nativePropsName = new Set([...elementPropsNames, ...Object.keys(events)]);
 
-
   /** create reference component */
-  const component = forwardRef((props?: ComponentProps, __ref?: Ref<E>) => {
+  const component = forwardRef((props, __ref?: Ref<E>) => {
     const ref = useForwardRef<E>(__ref);
 
     /** bind native properties and function */


### PR DESCRIPTION
Correct the typing in the `create-element` function to improve type safety and clarity.