### PR TITLE
chore: update @equinor/fusion-wc-person to version 3.2.4 and fix long…

### DIFF
--- a/.changeset/fine-plums-sniff.md
+++ b/.changeset/fine-plums-sniff.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-react-person": patch
+---
+
+Fixing issue with long names in PersonCard by updating fusion-wc-person

--- a/packages/person/package.json
+++ b/packages/person/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-person": "^3.2.3"
+    "@equinor/fusion-wc-person": "^3.2.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.74",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-person':
-        specifier: ^3.2.3
-        version: 3.2.3
+        specifier: ^3.2.4
+        version: 3.2.4
     devDependencies:
       '@types/react':
         specifier: ^18.2.74
@@ -1611,8 +1611,8 @@ packages:
   '@equinor/fusion-wc-markdown@1.3.2':
     resolution: {integrity: sha512-Wl4Vn7Lpa4CPQogN+aUiEUTRSA8HrS1UHwJlBsY2wLUVUSBcISOJPThoPJe3f4cpG7+b8ek/f+Pt9a37wTgQgg==}
 
-  '@equinor/fusion-wc-person@3.2.3':
-    resolution: {integrity: sha512-Iy3jdc0eYEMLQkoOPep8EqYGYyoOELXYYsnClNiiXJheqg+4XRwYKll3AyxLXzXWmUaUtj3CJx7a901lBNT/sQ==}
+  '@equinor/fusion-wc-person@3.2.4':
+    resolution: {integrity: sha512-F+RqZVFuzeo5EKgs3QANmEnBiCqK7OEKmVrCjVx6dMDky5h1C5CT4ERFLTouiqreS4icRiABetIarR7x5tmRmg==}
 
   '@equinor/fusion-wc-picture@3.1.1':
     resolution: {integrity: sha512-TeZd46sjyg43HHlbE4h9Ebk9wCBnif5j9XGodIdVTCaC7rLz2YEd7C6RS7vj3nS+goFIZmowiUUmg6gZemzY4w==}
@@ -10010,7 +10010,7 @@ snapshots:
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.1
 
-  '@equinor/fusion-wc-person@3.2.3':
+  '@equinor/fusion-wc-person@3.2.4':
     dependencies:
       '@equinor/fusion-wc-avatar': 3.2.3
       '@equinor/fusion-wc-badge': 1.3.2


### PR DESCRIPTION
Fixing issue with long names in PersonCard by updating fusion-wc-person

### Type

- [ ] Feature
- [ ] Fix
- [x] Hotfix (should release ASAP)
- [x] Maintenance (deps only)
