### PR TITLE
fix: remove sourceMap from tsconfig to stop shipping broken .js.map files

### DIFF
--- a/.changeset/remove-sourcemaps.md
+++ b/.changeset/remove-sourcemaps.md
@@ -1,0 +1,24 @@
+---
+"@equinor/fusion-react-ag-grid-person-cell": patch
+"@equinor/fusion-react-ag-grid-utils": patch
+"@equinor/fusion-react-components": patch
+"@equinor/fusion-react-context-selector": patch
+"@equinor/fusion-react-date": patch
+"@equinor/fusion-react-errorboundary": patch
+"@equinor/fusion-react-filter": patch
+"@equinor/fusion-react-hanging-garden": patch
+"@equinor/fusion-react-list": patch
+"@equinor/fusion-react-markdown": patch
+"@equinor/fusion-react-person": patch
+"@equinor/fusion-react-ripple": patch
+"@equinor/fusion-react-searchable-dropdown": patch
+"@equinor/fusion-react-side-sheet": patch
+"@equinor/fusion-react-skeleton": patch
+"@equinor/fusion-react-stepper": patch
+"@equinor/fusion-react-styles": patch
+"@equinor/fusion-react-tabs": patch
+"@equinor/fusion-react-textarea": patch
+"@equinor/fusion-react-utils": patch
+---
+
+Remove sourcemap generation from build output. Published packages no longer ship broken `.js.map` files that referenced missing source files, eliminating console warnings for consumers.

--- a/.changeset/update-wc-deps.md
+++ b/.changeset/update-wc-deps.md
@@ -1,0 +1,15 @@
+---
+"@equinor/fusion-react-person": patch
+"@equinor/fusion-react-context-selector": patch
+"@equinor/fusion-react-date": patch
+"@equinor/fusion-react-filter": patch
+"@equinor/fusion-react-list": patch
+"@equinor/fusion-react-markdown": patch
+"@equinor/fusion-react-ripple": patch
+"@equinor/fusion-react-searchable-dropdown": patch
+"@equinor/fusion-react-skeleton": patch
+"@equinor/fusion-react-styles": patch
+"@equinor/fusion-react-textarea": patch
+---
+
+Update `@equinor/fusion-wc-*` dependencies to latest versions which no longer ship broken sourcemaps.

--- a/packages/context-selector/package.json
+++ b/packages/context-selector/package.json
@@ -41,8 +41,8 @@
     "@equinor/fusion-react-searchable-dropdown": "workspace:^",
     "@equinor/fusion-react-styles": "workspace:^",
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-icon": "^2.3.1",
-    "@equinor/fusion-wc-searchable-dropdown": "^4.0.5"
+    "@equinor/fusion-wc-icon": "^2.4.1",
+    "@equinor/fusion-wc-searchable-dropdown": "^4.1.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-date": "^1.1.3"
+    "@equinor/fusion-wc-date": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@equinor/eds-tokens": "^2.2.0",
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-chip": "^1.2.2",
+    "@equinor/fusion-wc-chip": "^1.3.1",
     "rxjs": "^7.8.1",
     "styled-components": "^6.1.8",
     "typesafe-actions": "^5.1.0"

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-list": "^1.1.4"
+    "@equinor/fusion-wc-list": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-markdown": "^1.5.1"
+    "@equinor/fusion-wc-markdown": "^1.6.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/person/package.json
+++ b/packages/person/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-people": "2.1.0",
-    "@equinor/fusion-wc-person": "3.5.0"
+    "@equinor/fusion-wc-people": "2.1.1",
+    "@equinor/fusion-wc-person": "3.5.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-ripple": "^1.1.1"
+    "@equinor/fusion-wc-ripple": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/searchable-dropdown/package.json
+++ b/packages/searchable-dropdown/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-icon": "^2.3.1",
-    "@equinor/fusion-wc-searchable-dropdown": "^4.0.5"
+    "@equinor/fusion-wc-icon": "^2.4.1",
+    "@equinor/fusion-wc-searchable-dropdown": "^4.1.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-skeleton": "^2.1.2"
+    "@equinor/fusion-wc-skeleton": "^2.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@equinor/eds-tokens": "^2.2.0",
-    "@equinor/fusion-wc-theme": "^1.1.2",
+    "@equinor/fusion-wc-theme": "^1.2.1",
     "@equinor/fusion-web-theme": "^0.1.10",
     "clsx": "^2.1.0",
     "hoist-non-react-statics": "^3.3.2",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:^",
-    "@equinor/fusion-wc-textarea": "^1.1.4"
+    "@equinor/fusion-wc-textarea": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,11 +120,11 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-icon':
-        specifier: ^2.3.1
-        version: 2.4.0
+        specifier: ^2.4.1
+        version: 2.4.1
       '@equinor/fusion-wc-searchable-dropdown':
-        specifier: ^4.0.5
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -139,8 +139,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-date':
-        specifier: ^1.1.3
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -192,8 +192,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-chip':
-        specifier: ^1.2.2
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       react-dom:
         specifier: ^18 || ^19
         version: 19.2.5(react@19.2.5)
@@ -260,8 +260,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-list':
-        specifier: ^1.1.4
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -276,8 +276,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-markdown':
-        specifier: ^1.5.1
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -292,11 +292,11 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-people':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: 2.1.1
+        version: 2.1.1
       '@equinor/fusion-wc-person':
-        specifier: 3.5.0
-        version: 3.5.0
+        specifier: 3.5.1
+        version: 3.5.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -311,8 +311,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-ripple':
-        specifier: ^1.1.1
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -327,11 +327,11 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-icon':
-        specifier: ^2.3.1
-        version: 2.4.0
+        specifier: ^2.4.1
+        version: 2.4.1
       '@equinor/fusion-wc-searchable-dropdown':
-        specifier: ^4.0.5
-        version: 4.1.0
+        specifier: ^4.1.1
+        version: 4.1.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -383,8 +383,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-skeleton':
-        specifier: ^2.1.2
-        version: 2.2.0
+        specifier: ^2.2.1
+        version: 2.2.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -424,8 +424,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@equinor/fusion-wc-theme':
-        specifier: ^1.1.2
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
       '@equinor/fusion-web-theme':
         specifier: ^0.1.10
         version: 0.1.10
@@ -528,8 +528,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@equinor/fusion-wc-textarea':
-        specifier: ^1.1.4
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -693,11 +693,11 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(@types/react@19.2.14)(react@19.2.5)
       '@equinor/fusion-wc-avatar':
-        specifier: ^3.2.0
-        version: 3.3.0
+        specifier: ^3.3.1
+        version: 3.3.1
       '@equinor/fusion-wc-icon':
-        specifier: ^2.3.0
-        version: 2.4.0
+        specifier: ^2.4.1
+        version: 2.4.1
       '@faker-js/faker':
         specifier: ^10.0.0
         version: 10.4.0
@@ -1337,8 +1337,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bufbuild/protobuf@2.11.0':
-    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
 
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
@@ -1692,71 +1692,71 @@ packages:
       '@types/react':
         optional: true
 
-  '@equinor/fusion-wc-avatar@3.3.0':
-    resolution: {integrity: sha512-LTDw2Vhur1Syd/fB0cz8EqCRRySfkLeHWSq3fRTf4cf4Z1+Z+9AfqpCkoKEwfwnkuvlcp8NPTf3a1VYaJH9eoQ==}
+  '@equinor/fusion-wc-avatar@3.3.1':
+    resolution: {integrity: sha512-Z+8lmqUtmoJ6kOgOd1qKYQpw+CYXtNJBfkpiUiLPBViNq/hf+8ApB5NKdj5TxDa8TSaxzzhVqKfL+LMz+TlY/A==}
 
-  '@equinor/fusion-wc-button@2.5.0':
-    resolution: {integrity: sha512-b8QBqMveHMWy4HGudnIyRaF7NpkO5e4nQ3e1M6vX843Abwfl06vUdxT/7RpYG9biUmgAZHi07j1zpfWf5cwlDQ==}
+  '@equinor/fusion-wc-button@2.5.1':
+    resolution: {integrity: sha512-W1/UProYT+LYTZt499Y/jn2JX6ZXEv1fE8BbiRIyVXCFUYuVy50JmERuWV5SoPhGiuB4BGmZMTcnjO1jKu6tIg==}
 
-  '@equinor/fusion-wc-checkbox@1.2.0':
-    resolution: {integrity: sha512-bimJKRjLDH8fv/AOphCN5NE5XWlJJiDsGy64VogCueyy5qKW/ODStzlrfAJdISJ0bW7XwJ1OGdjDoE4LLGQixA==}
+  '@equinor/fusion-wc-checkbox@1.2.1':
+    resolution: {integrity: sha512-c9pC+mmcxAxa9vYVNl30lVtl7o1THp/tQMqmEhKh3dBSvdtmoEpI//ORdwbJa1QhEkSDALmaW5aaWoQtn4Fc0Q==}
 
-  '@equinor/fusion-wc-chip@1.3.0':
-    resolution: {integrity: sha512-YeuDfU3vgDqzDUtNqB4JeXMv7mMOhEXWabt0DLnIE1c/EK7wMuZ43nCfVEopBGzWRIph8wjethX9gNXMDq7sEw==}
+  '@equinor/fusion-wc-chip@1.3.1':
+    resolution: {integrity: sha512-PZ+8EdKydfkxWWGF31efDJuTSX3zg0J8AHSyntYhJjJfwLcqdZ8eFbmYBnMOR3JkA5IQFFwMVgZ7pmNtDC1gRQ==}
 
-  '@equinor/fusion-wc-core@2.0.0':
-    resolution: {integrity: sha512-yxUepfQhMIkKNYn2Vc73R6/cyvyO0hde3LXFitCCaa8QR9woK0UXZlxP+RwnEYzve528l9K1t7SnEsX6x5eyPg==}
+  '@equinor/fusion-wc-core@2.0.1':
+    resolution: {integrity: sha512-9CWaWs9CrCA8U2KlMj/BWwO3JNs7FD+5JuPYMPBDKfiS/RYtJt0eRj7oHL45FFjapZ9LbgApJA5cb54qEHm7Bw==}
 
-  '@equinor/fusion-wc-date@1.2.0':
-    resolution: {integrity: sha512-i6oH9e2ee8Tveuq10V/40WDXUrNFVMGNIYwl9Kb0JD+t5agavMD/IAMhqMFfzB8lp7nsi8/7mNQ2OL7SvIxJtQ==}
+  '@equinor/fusion-wc-date@1.2.1':
+    resolution: {integrity: sha512-tvuxfXZtqioJXG03FNlnvDTzbBchOX1ERT/gqNsKNQPcvPTB/vX6jfcOCpKHcgl5qKTcvxH9Mf6P+PwWDlh7yQ==}
 
-  '@equinor/fusion-wc-divider@1.2.0':
-    resolution: {integrity: sha512-eFE28WjzU2aWfcpkxP10chlcPN0veb3pka8kHvekj81pStjda7FS3YRuewND6ZPXwssaAe1a8WJDEj1RAliRpA==}
+  '@equinor/fusion-wc-divider@1.2.1':
+    resolution: {integrity: sha512-H0aUUHQ/kCjYOlBU6lgvgQJu/0vdN1KYZ9tv1fOdZ0RAV8hITrIOE11/+sJ3K2AVkmgpqvyQQoG80jcB42sEOw==}
 
-  '@equinor/fusion-wc-formfield@1.2.0':
-    resolution: {integrity: sha512-2Atf9KLWPN6MlrdVCWhdWzagBARvg9APXyg2+zbz/N9EA0SZSFlFPqtq5hOPLZg9Xg8zVQJIKrsVO1Bs4e+ypg==}
+  '@equinor/fusion-wc-formfield@1.2.1':
+    resolution: {integrity: sha512-mdlHTmTWIWM3nu5F7VQLaYvsDBcK0HTiXV2WUvgecsOcFLoMMZwScxN3IfbfhhNgCGC+t/Sr+V5ubtQHgkgc2A==}
 
-  '@equinor/fusion-wc-icon@2.4.0':
-    resolution: {integrity: sha512-BjbP7YNSlRtgMlFMmLKIZidtV8O14naW1kXh55Kvsxqy834iBjHQ64KooTs61tJ52pE49LHXayHPgxUhVip7JA==}
+  '@equinor/fusion-wc-icon@2.4.1':
+    resolution: {integrity: sha512-7thlJS7C/4TxzFRv9wV+CnIuhNuKYFFHwlLpYDHEV4mJv4lq4Om/K1Z8QHVj1Tsg9TDNrEGe7MJZt7tF7cDa8w==}
 
-  '@equinor/fusion-wc-list@1.2.0':
-    resolution: {integrity: sha512-+7QJ+qb4SNbjo6Ox466Fv/BY4ddnZRs8ynG56IztsW600SO0pj8lF8BQN8y+5z25dNZ15DAkUOjtprGmWVHLow==}
+  '@equinor/fusion-wc-list@1.2.1':
+    resolution: {integrity: sha512-ctrFk+nKYPsHE/58POYqT76aWTw98B0Eip6XXXdaZ91MqUoHWsf3eTdqhaMqyiBoRUvCFzhPuMmCU+Yeg/3rMA==}
 
-  '@equinor/fusion-wc-markdown@1.6.0':
-    resolution: {integrity: sha512-6+bAnkglCU6Qb0asuuGigy+UOxVBFgetSzJAjAGVlwayEP31iGRenKx2KbxIYvhqNNOTVYvSGYB0rfNW4jhTCw==}
+  '@equinor/fusion-wc-markdown@1.6.1':
+    resolution: {integrity: sha512-S2TbXhpW8kcXfq2mVeVskdy5JoVcfwUTTw+ZJijLkRt5EK+Pr1Au3OOMdkRS9B339tHt+g4bZIPA0tbSwXRNAw==}
 
-  '@equinor/fusion-wc-people@2.1.0':
-    resolution: {integrity: sha512-4j/OKDsKPPle8K1hqlpPEeHJt8RwsrPr68runP3hMjQ6bvxgWSp3v4lC3DaTxRU8qq5LHHwhSwPeTNpZiCaPeg==}
+  '@equinor/fusion-wc-people@2.1.1':
+    resolution: {integrity: sha512-N3twPNfFcj58zTrniBen9vmgY8M4toBzsrq2bh1vJq7Ic+uesN0Tm8sVcgh0S50bOPv0aSRBXXcSgSQE+XbrYQ==}
 
-  '@equinor/fusion-wc-person@3.5.0':
-    resolution: {integrity: sha512-9k+kosY9xwBEu5Qfe8wMHTkc1N6WN+O1uJg4dbLUNfJq5Fs/L8cs+LBnYbCm332TiQ9Vgzpek8KlCfOojXdScw==}
+  '@equinor/fusion-wc-person@3.5.1':
+    resolution: {integrity: sha512-v5WDhxcRy5PNq5V9SxE6tOlUWZfwfcAZIPml6R/Iek+YZ4rR0DxYeZdQh+ckOU1B652auZFfoSQwXy0qC4ilzA==}
 
-  '@equinor/fusion-wc-picture@3.2.0':
-    resolution: {integrity: sha512-SjZuZVoYIGTf1wwj32Td50iMkLfYaUGVdScBqqIL3qwJQ/I1xrZeaYLStqlw5ifhMAhGAIc6ldTl2Ey2UqVfjg==}
+  '@equinor/fusion-wc-picture@3.2.1':
+    resolution: {integrity: sha512-DcZ8wIZCseXCtaFsDxgf4vNTh+9HXvOEmZa70l3zmB50q5kIciU601Qn1c3AJf/HeHs8FprF8FH4R/R3LrUbqw==}
 
-  '@equinor/fusion-wc-progress-indicator@1.2.0':
-    resolution: {integrity: sha512-T14FT4wJcgrNKVPjnRXHE6/tOFP43KC4WM1TuEhlpOgJf4iqhcnA3XqHswUzACHCdKbXHzg3TXeh1OqlZbosHA==}
+  '@equinor/fusion-wc-progress-indicator@1.2.1':
+    resolution: {integrity: sha512-mpr0LqKxg53ejdLDIRSbF5TSRLacx+O6zYiYypgLLx9RzVjDnnOOpp30XBMxeOO15nGbJ306gvZy1C7e0es/GA==}
 
-  '@equinor/fusion-wc-radio@1.2.0':
-    resolution: {integrity: sha512-m0rPpp0QLeE+WdXU9xe/Hhp/nAQDlKFWaQ4GKQ6rlmK+tjcJs7Hv8xHlVIYt0AYcXLU6qU8+J9ih8vSOkk0ulA==}
+  '@equinor/fusion-wc-radio@1.2.1':
+    resolution: {integrity: sha512-9CMf4dXD2AOEok6RFBvdFd4NBeiWVkKG9xVLW3hofqc/z9wPYsm6YXSO3SrOFAaV0furZcgOpC90VXRhD1WO+A==}
 
-  '@equinor/fusion-wc-ripple@1.2.0':
-    resolution: {integrity: sha512-9IbnC1N9c/BCuxwCQkv4ckeBEsxCxPsX2GpPIprwmJWiI63HRohHG7fHtGK3fwkWVNOdiYmn0Kd+vr9JqubQmg==}
+  '@equinor/fusion-wc-ripple@1.2.1':
+    resolution: {integrity: sha512-q+kY0Jxk4UU8+fsOYREYaPiKt8OMWF4NYrWsYWRtcaRrs4RVMTsP+QxLNB8DFtYqM2TK4F1zv3bce30I/guOrw==}
 
-  '@equinor/fusion-wc-searchable-dropdown@4.1.0':
-    resolution: {integrity: sha512-Khax3pq89t0+DDfq/vltwsDODZs3LxQxOBdVN4uUGfLqAonkYQR3exTVYNntxuTKpp5XMZMMsko2VgsQcfnOiA==}
+  '@equinor/fusion-wc-searchable-dropdown@4.1.1':
+    resolution: {integrity: sha512-p2/7MVsYGXVIZzG09BNmjGiaVt2jQX1EbplFvCVL8gcMTfQbSs6nB7TysyrKZFIFvWGm33Mc0OaW93MHVHIcFQ==}
 
-  '@equinor/fusion-wc-skeleton@2.2.0':
-    resolution: {integrity: sha512-xNLP96nu3vvFmLr/HWmdv3mrK9Rc94Z64pfDOS10WOiWyWq2Kew3CAwvrS2VfcNT2HWSrZNYTCVf9MHkb7OW5w==}
+  '@equinor/fusion-wc-skeleton@2.2.1':
+    resolution: {integrity: sha512-d+Q42C/izATYSFzOIVTEisSE1Hyl+WQc+RFEmWSlq4JNh/iJzmIyY3P/nU10FsEHRK7iEBjgKIPc93XewQeKbg==}
 
-  '@equinor/fusion-wc-textarea@1.2.0':
-    resolution: {integrity: sha512-1xu14t4NmlYaxYpC5Q5AcbvwK4xe6FWsVrQ0gr2UYLfoB7A4ObEcs6/EMq8hW8jQi5GGgn+IaEi00lTdzoJWng==}
+  '@equinor/fusion-wc-textarea@1.2.1':
+    resolution: {integrity: sha512-qOSPIOINNy573wocB91e0FVg3o5xmJnD0eNn1BdtnJ+HgCgJ9RKiytHkN9ffWHeXXhz0ytrDjyefeuBK1gZZoQ==}
 
-  '@equinor/fusion-wc-textinput@1.2.0':
-    resolution: {integrity: sha512-9r1reXhaCbHdjXFtCRZGpoqW7oKe/8RAlPcpQwqvljaxPC7ucLJw3kVScKEHJH6MMWuc8R+/YyQAGgVMq75yiA==}
+  '@equinor/fusion-wc-textinput@1.2.1':
+    resolution: {integrity: sha512-9j9BgABBNYaQoqQl/iGfKNZVRyMxWhYEJaOXgUajGrE1sho+0Bs1827a9+hHJYrJ1jK55yZM5lOuTATOftH+7Q==}
 
-  '@equinor/fusion-wc-theme@1.2.0':
-    resolution: {integrity: sha512-vWySsYaD2QyIaoYORd3wOWc1Ak0dKg37ozP3dt031CQgbv5Zh05h4zlCywmdx9/65gir7b7sCE8cdE0c0euRZw==}
+  '@equinor/fusion-wc-theme@1.2.1':
+    resolution: {integrity: sha512-ZZ047PglAqwg6NlAHpJAP/00NiMJHv4KqjqaSemikP1afvHmMEfG9Z6eQIWdRkw6LTx53gj8tEWqhZjGpSoM2w==}
 
   '@equinor/fusion-web-theme@0.1.10':
     resolution: {integrity: sha512-/Yzfie73UvMoBMo35gmeHO+5nTty5EyemomcB5ZbEDyHFNIodgCL1JGm2KfrIwqez9w9CTneHjnJWvwhu9TM+w==}
@@ -4373,6 +4373,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -5008,8 +5011,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.20.1:
-    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
@@ -5798,6 +5801,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
@@ -5971,8 +5977,8 @@ packages:
     resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
     engines: {node: '>=8'}
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@2.0.0:
@@ -6086,8 +6092,8 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
-  marked@17.0.6:
-    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+  marked@18.0.2:
+    resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -7581,8 +7587,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tapable@2.3.2:
-    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@2.2.0:
@@ -7600,8 +7606,8 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  terser-webpack-plugin@5.4.0:
-    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -7899,6 +7905,10 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -8036,8 +8046,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webpack-sources@3.3.4:
-    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
+  webpack-sources@3.4.0:
+    resolution: {integrity: sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.6.2:
@@ -8997,7 +9007,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bufbuild/protobuf@2.11.0':
+  '@bufbuild/protobuf@2.12.0':
     optional: true
 
   '@changesets/apply-release-plan@7.1.0':
@@ -9541,85 +9551,85 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@equinor/fusion-wc-avatar@3.3.0':
+  '@equinor/fusion-wc-avatar@3.3.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-picture': 3.2.0
-      '@equinor/fusion-wc-ripple': 1.2.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-picture': 3.2.1
+      '@equinor/fusion-wc-ripple': 1.2.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
 
-  '@equinor/fusion-wc-button@2.5.0':
+  '@equinor/fusion-wc-button@2.5.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-icon': 2.4.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-icon': 2.4.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-button': 0.27.0
       '@material/mwc-icon-button': 0.27.0
       '@material/mwc-icon-button-toggle': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-checkbox@1.2.0':
+  '@equinor/fusion-wc-checkbox@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-checkbox': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-chip@1.3.0':
+  '@equinor/fusion-wc-chip@1.3.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-icon': 2.4.0
-      '@equinor/fusion-wc-ripple': 1.2.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-icon': 2.4.1
+      '@equinor/fusion-wc-ripple': 1.2.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
 
-  '@equinor/fusion-wc-core@2.0.0': {}
+  '@equinor/fusion-wc-core@2.0.1': {}
 
-  '@equinor/fusion-wc-date@1.2.0':
+  '@equinor/fusion-wc-date@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       date-fns: 4.1.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-divider@1.2.0':
+  '@equinor/fusion-wc-divider@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
 
-  '@equinor/fusion-wc-formfield@1.2.0':
+  '@equinor/fusion-wc-formfield@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-formfield': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-icon@2.4.0':
+  '@equinor/fusion-wc-icon@2.4.1':
     dependencies:
       '@equinor/eds-icons': 1.4.0
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       lit: 3.3.2
 
-  '@equinor/fusion-wc-list@1.2.0':
+  '@equinor/fusion-wc-list@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-checkbox': 1.2.0
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-divider': 1.2.0
-      '@equinor/fusion-wc-icon': 2.4.0
-      '@equinor/fusion-wc-radio': 1.2.0
+      '@equinor/fusion-wc-checkbox': 1.2.1
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-divider': 1.2.1
+      '@equinor/fusion-wc-icon': 2.4.1
+      '@equinor/fusion-wc-radio': 1.2.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-list': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-markdown@1.6.0':
+  '@equinor/fusion-wc-markdown@1.6.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-icon': 2.4.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-icon': 2.4.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
-      marked: 17.0.6
+      marked: 18.0.2
       prismjs: 1.30.0
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
@@ -9633,97 +9643,97 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@equinor/fusion-wc-people@2.1.0':
+  '@equinor/fusion-wc-people@2.1.1':
     dependencies:
-      '@equinor/fusion-wc-button': 2.5.0
-      '@equinor/fusion-wc-checkbox': 1.2.0
-      '@equinor/fusion-wc-chip': 1.3.0
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-formfield': 1.2.0
-      '@equinor/fusion-wc-icon': 2.4.0
-      '@equinor/fusion-wc-person': 3.5.0
-      '@equinor/fusion-wc-progress-indicator': 1.2.0
-      '@equinor/fusion-wc-skeleton': 2.2.0
+      '@equinor/fusion-wc-button': 2.5.1
+      '@equinor/fusion-wc-checkbox': 1.2.1
+      '@equinor/fusion-wc-chip': 1.3.1
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-formfield': 1.2.1
+      '@equinor/fusion-wc-icon': 2.4.1
+      '@equinor/fusion-wc-person': 3.5.1
+      '@equinor/fusion-wc-progress-indicator': 1.2.1
+      '@equinor/fusion-wc-skeleton': 2.2.1
       '@equinor/fusion-web-theme': 0.1.10
       '@lit/context': 1.1.6
       lit: 3.3.0
 
-  '@equinor/fusion-wc-person@3.5.0':
+  '@equinor/fusion-wc-person@3.5.1':
     dependencies:
-      '@equinor/fusion-wc-button': 2.5.0
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-icon': 2.4.0
-      '@equinor/fusion-wc-list': 1.2.0
-      '@equinor/fusion-wc-searchable-dropdown': 4.1.0
-      '@equinor/fusion-wc-skeleton': 2.2.0
-      '@equinor/fusion-wc-textinput': 1.2.0
+      '@equinor/fusion-wc-button': 2.5.1
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-icon': 2.4.1
+      '@equinor/fusion-wc-list': 1.2.1
+      '@equinor/fusion-wc-searchable-dropdown': 4.1.1
+      '@equinor/fusion-wc-skeleton': 2.2.1
+      '@equinor/fusion-wc-textinput': 1.2.1
       '@equinor/fusion-web-theme': 0.1.10
       '@floating-ui/dom': 1.7.6
       '@lit-labs/observers': 2.1.0
       '@lit/task': 1.0.3
       lit: 3.3.2
 
-  '@equinor/fusion-wc-picture@3.2.0':
+  '@equinor/fusion-wc-picture@3.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       lit: 3.3.2
 
-  '@equinor/fusion-wc-progress-indicator@1.2.0':
+  '@equinor/fusion-wc-progress-indicator@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
 
-  '@equinor/fusion-wc-radio@1.2.0':
+  '@equinor/fusion-wc-radio@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-radio': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-ripple@1.2.0':
+  '@equinor/fusion-wc-ripple@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@material/mwc-ripple': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-searchable-dropdown@4.1.0':
+  '@equinor/fusion-wc-searchable-dropdown@4.1.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-divider': 1.2.0
-      '@equinor/fusion-wc-icon': 2.4.0
-      '@equinor/fusion-wc-list': 1.2.0
-      '@equinor/fusion-wc-textinput': 1.2.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-divider': 1.2.1
+      '@equinor/fusion-wc-icon': 2.4.1
+      '@equinor/fusion-wc-list': 1.2.1
+      '@equinor/fusion-wc-textinput': 1.2.1
       '@equinor/fusion-web-theme': 0.1.10
       '@lit-labs/task': 3.1.0
       '@types/uuid': 11.0.0
       lit: 3.3.2
-      uuid: 13.0.0
+      uuid: 14.0.0
 
-  '@equinor/fusion-wc-skeleton@2.2.0':
+  '@equinor/fusion-wc-skeleton@2.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       lit: 3.3.2
 
-  '@equinor/fusion-wc-textarea@1.2.0':
+  '@equinor/fusion-wc-textarea@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-textinput': 1.2.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-textinput': 1.2.1
       '@material/mwc-textarea': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-textinput@1.2.0':
+  '@equinor/fusion-wc-textinput@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
-      '@equinor/fusion-wc-icon': 2.4.0
+      '@equinor/fusion-wc-core': 2.0.1
+      '@equinor/fusion-wc-icon': 2.4.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/mwc-textfield': 0.27.0
       lit: 3.3.2
 
-  '@equinor/fusion-wc-theme@1.2.0':
+  '@equinor/fusion-wc-theme@1.2.1':
     dependencies:
-      '@equinor/fusion-wc-core': 2.0.0
+      '@equinor/fusion-wc-core': 2.0.1
       '@equinor/fusion-web-theme': 0.1.10
       '@material/theme': 14.0.0
       lit: 3.3.2
@@ -12859,7 +12869,7 @@ snapshots:
 
   '@types/uuid@11.0.0':
     dependencies:
-      uuid: 13.0.0
+      uuid: 14.0.0
 
   '@types/whatwg-mimetype@3.0.2':
     optional: true
@@ -13132,14 +13142,14 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
     optional: true
 
-  ajv-keywords@5.1.0(ajv@8.18.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
     optional: true
 
@@ -13149,6 +13159,14 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    optional: true
 
   ansi-colors@4.1.3: {}
 
@@ -13771,10 +13789,10 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.20.1:
+  enhanced-resolve@5.21.0:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.2
+      tapable: 2.3.3
     optional: true
 
   enquirer@2.3.6:
@@ -14022,7 +14040,7 @@ snapshots:
   fs-extra@11.1.1:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-extra@11.3.4:
@@ -14595,6 +14613,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonparse@1.3.1: {}
 
   jss-plugin-camel-case@10.10.0:
@@ -14885,7 +14909,7 @@ snapshots:
       strip-bom: 4.0.0
       type-fest: 0.6.0
 
-  loader-runner@4.3.1:
+  loader-runner@4.3.2:
     optional: true
 
   locate-path@2.0.0:
@@ -15015,7 +15039,7 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  marked@17.0.6: {}
+  marked@18.0.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -16304,7 +16328,7 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       react: 19.2.5
-      react-is: 18.3.1
+      react-is: 17.0.2
     optional: true
 
   react-test-renderer@17.0.2(react@19.2.5):
@@ -16629,7 +16653,7 @@ snapshots:
 
   sass-embedded@1.97.2:
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
+      '@bufbuild/protobuf': 2.12.0
       buffer-builder: 0.2.0
       colorjs.io: 0.5.2
       immutable: 5.1.5
@@ -16688,9 +16712,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
     optional: true
 
   semver-compare@1.0.0: {}
@@ -16976,7 +17000,7 @@ snapshots:
   tagged-tag@1.0.0:
     optional: true
 
-  tapable@2.3.2:
+  tapable@2.3.3:
     optional: true
 
   tar-stream@2.2.0:
@@ -17001,7 +17025,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)):
+  terser-webpack-plugin@5.5.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -17259,6 +17283,8 @@ snapshots:
 
   uuid@13.0.0: {}
 
+  uuid@14.0.0: {}
+
   uuid@8.3.2:
     optional: true
 
@@ -17369,7 +17395,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-sources@3.3.4:
+  webpack-sources@3.4.0:
     optional: true
 
   webpack-virtual-modules@0.6.2: {}
@@ -17386,21 +17412,21 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.21.0
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7))
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7)(webpack@5.102.1(@swc/core@1.15.8(@swc/helpers@0.5.17))(esbuild@0.27.7))
       watchpack: 2.5.1
-      webpack-sources: 3.3.4
+      webpack-sources: 3.4.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -60,8 +60,8 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@equinor/fusion-observable": "^9.0.0",
-    "@equinor/fusion-wc-avatar": "^3.2.0",
-    "@equinor/fusion-wc-icon": "^2.3.0",
+    "@equinor/fusion-wc-avatar": "^3.3.1",
+    "@equinor/fusion-wc-icon": "^2.4.1",
     "@faker-js/faker": "^10.0.0",
     "@storybook/builder-vite": "^10.0.2",
     "@types/react": "^19.2.14"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,6 @@
     "declaration": true,
     "declarationMap": true,
     "composite": true,
-    "sourceMap": true,
     "rootDir": ".",
     "lib": ["esnext", "dom"],
     "paths": {


### PR DESCRIPTION
## Summary

Removes `sourceMap` and `inlineSources` from `tsconfig.base.json` so that `.js.map` files are no longer generated or shipped in published npm packages.

## Problem

Consumers of `@equinor/fusion-react-*` packages see console warnings like:

> Sourcemap for `"node_modules/@equinor/{some-fusion-package}/lib/{some-file}"` points to missing source files

This happens because the sourcemaps reference `../src/*.ts` paths via relative references, but `src/` is not included in the published packages (`"files": ["dist"]`).

## Solution

Stop generating `.js.map` files entirely — matching the approach used by MUI and Chakra UI.

`declarationMap` is preserved so that "Go to Definition" still navigates consumers into the library's `.d.ts` files.

ref equinor/fusion-core-tasks#983