### PR TITLE
chore: add changesets for dependency updates

### DIFF
--- a/.changeset/dep-fusion-observable.md
+++ b/.changeset/dep-fusion-observable.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-react-filter": patch
+"@equinor/fusion-react-tabs": patch
+---
+
+Bump `@equinor/fusion-observable` from 9.0.0 to 9.0.1 — internal `uuid` dependency updated from 13.0.0 to 14.0.0.

--- a/.changeset/dep-styled-components.md
+++ b/.changeset/dep-styled-components.md
@@ -1,0 +1,12 @@
+---
+"@equinor/fusion-react-filter": patch
+"@equinor/fusion-react-ag-grid-person-cell": patch
+"@equinor/fusion-react-ag-grid-utils": patch
+"@equinor/fusion-react-errorboundary": patch
+"@equinor/fusion-react-side-sheet": patch
+"@equinor/fusion-react-stepper": patch
+"@equinor/fusion-react-styles": patch
+"@equinor/fusion-react-tabs": patch
+---
+
+Bump `styled-components` from 6.4.0 to 6.4.1 — fixes a performance regression in `createGlobalStyle` and updates stale dev-mode error messages.

--- a/.changeset/dep-typescript.md
+++ b/.changeset/dep-typescript.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-react-side-sheet": patch
+"@equinor/fusion-react-tabs": patch
+---
+
+Bump `typescript` from 6.0.2 to 6.0.3 — hardens ATA package name filtering and fixes class property initializer handling.

--- a/.changeset/dep-vite.md
+++ b/.changeset/dep-vite.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-react-filter": patch
+---
+
+Bump `vite` from 8.0.8 to 8.0.10 — rolldown RC update, CSS minification warning improvements, and optimizer fixes.


### PR DESCRIPTION
## Changesets for dependency updates

Adds patch changesets for all components affected by the recent Dependabot merges:

### styled-components 6.4.0 → 6.4.1
- `@equinor/fusion-react-filter`
- `@equinor/fusion-react-ag-grid-person-cell`
- `@equinor/fusion-react-ag-grid-utils`
- `@equinor/fusion-react-errorboundary`
- `@equinor/fusion-react-side-sheet`
- `@equinor/fusion-react-stepper`
- `@equinor/fusion-react-styles`
- `@equinor/fusion-react-tabs`

### @equinor/fusion-observable 9.0.0 → 9.0.1
- `@equinor/fusion-react-filter`
- `@equinor/fusion-react-tabs`

### vite 8.0.8 → 8.0.10
- `@equinor/fusion-react-filter`

### typescript 6.0.2 → 6.0.3
- `@equinor/fusion-react-side-sheet`
- `@equinor/fusion-react-tabs`