### PR TITLE
feat: move EDS index infrastructure from fusion-framework

### DIFF
--- a/.github/workflows/index-eds.yml
+++ b/.github/workflows/index-eds.yml
@@ -72,7 +72,6 @@ on:
 
 env:
   EDS_REPO: equinor/design-system
-  CONFIG_PATH: ./eds/fusion-ai.config.eds.ts
 
 concurrency:
   group: index-eds
@@ -230,15 +229,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js and install dependencies
-        uses: ./.github/workflows/actions/node-setup
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install EDS index dependencies
+        working-directory: eds
+        run: npm install --ignore-scripts
 
       # Reads the index name (e.g. "eds-2026-03-14") from the config file
       # for use in the ensure-index and summary steps.
       - name: Read index name from config
         id: index
         run: |
-          index_name=$(node -e "import('$CONFIG_PATH').then(m => console.log(m.default.index.name))")
+          index_name=$(node -e "import('./eds/fusion-ai.config.eds.ts').then(m => console.log(m.default.index.name))")
           echo "name=${index_name}" >> "$GITHUB_OUTPUT"
           echo "::notice::Index name: ${index_name}"
 
@@ -324,9 +329,10 @@ jobs:
       # or validates the schema matches if it does. Safe to run every time.
       - name: Ensure index exists
         if: steps.diff.outputs.has_changes == 'true' || inputs.clean
+        working-directory: eds
         env:
           FUSION_ENV: ${{ vars.FUSION_ENV }}
-        run: pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index create --env "$FUSION_ENV" --config "$CONFIG_PATH"
+        run: npx ffc ai index create --env "$FUSION_ENV" --config ./fusion-ai.config.eds.ts
 
       # Three modes:
       #   --clean (manual dispatch): wipes all existing embeddings, re-indexes everything
@@ -343,15 +349,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          config="${{ github.workspace }}/eds/fusion-ai.config.eds.ts"
+
           if [[ "${INPUT_CLEAN:-false}" == "true" ]]; then
             echo "::notice::Clean rebuild — re-indexing all documents"
-            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --clean --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+            npx --prefix ../eds ffc ai index add --clean --env "$FUSION_ENV" --config "$config"
           elif [[ "$HAS_PREVIOUS" == "true" ]]; then
             echo "::notice::Incremental index — processing only changed files"
-            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --diff --base-ref HEAD~1 --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+            npx --prefix ../eds ffc ai index add --diff --base-ref HEAD~1 --env "$FUSION_ENV" --config "$config"
           else
             echo "::notice::First run — indexing all documents"
-            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+            npx --prefix ../eds ffc ai index add --env "$FUSION_ENV" --config "$config"
           fi
 
       # Persist the current content as the baseline for the next run.

--- a/.github/workflows/index-eds.yml
+++ b/.github/workflows/index-eds.yml
@@ -1,0 +1,391 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Index EDS Docs
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Keeps the EDS AI Search index in sync with the latest Equinor Design System
+# release. The workflow extracts component docs, design tokens, and foundation
+# content from the EDS Storybook, then embeds only the changed files into
+# Azure AI Search.
+#
+# ## How it works
+#
+# 1. **resolve-ref** — Finds the latest `@equinor/eds-core-react` release tag
+#    from `equinor/design-system`. Compares it against the `.eds-ref` file on
+#    the `eds-content` orphan branch to skip runs when nothing changed.
+#
+# 2. **build-eds** — Runs a multi-stage Docker build (`eds/docker/Dockerfile`) that:
+#    - Clones the EDS repo and builds Storybook
+#    - Extracts LLM docs via `storybook-llms-extractor`
+#    - Converts design tokens JSON → markdown
+#    - Trims and patches extracted content
+#    The output is a flat directory of markdown files.
+#
+# 3. **index-eds** — Fetches the previous content snapshot from the
+#    `eds-content` orphan branch, commits the new content on top, and runs
+#    `ffc ai index add --diff --base-ref HEAD~1` so only changed files are
+#    re-embedded. On first run (no orphan branch), indexes everything.
+#    After success, pushes the new snapshot to `eds-content` for next time.
+#
+# ## Manual dispatch
+#
+# Use workflow_dispatch to:
+# - Build a specific EDS ref (tag, branch, or SHA)
+# - Force a clean rebuild (`clean: true`) that wipes and re-indexes all docs
+# - Target a specific GitHub environment for Azure credentials
+#
+# ## Required environment variables (GitHub environment)
+#
+# | Variable                  | Purpose                              |
+# |---------------------------|--------------------------------------|
+# | `FUSION_AI_SP_CLIENT_ID`  | Azure AD app registration client ID  |
+# | `FUSION_ENV`              | Fusion environment (e.g. `ci`, `fprd`) |
+#
+# ## Key branches
+#
+# - `eds-content` — orphan branch storing the last-indexed content snapshot.
+#   Contains a `.eds-ref` file with the EDS release tag, which resolve-ref
+#   reads to determine whether a new run is needed.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Index EDS Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      eds_ref:
+        description: 'EDS git ref to build (tag, branch, or commit SHA)'
+        type: string
+        default: main
+      clean:
+        description: 'Delete existing embeddings before indexing'
+        type: boolean
+        default: false
+      environment:
+        description: 'GitHub environment with Azure credentials'
+        type: string
+        required: true
+
+  schedule:
+    # Every Monday 06:00 UTC — check for new EDS releases
+    - cron: '0 6 * * 1'
+
+env:
+  EDS_REPO: equinor/design-system
+  CONFIG_PATH: ./eds/fusion-ai.config.eds.ts
+
+concurrency:
+  group: index-eds
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Resolve which EDS ref to build ─────────────────────────────────────────
+  # Determines the EDS release to index and short-circuits when nothing changed.
+  # On manual dispatch, uses the provided ref directly.
+  # On schedule, queries the latest @equinor/eds-core-react release and compares
+  # it against the `.eds-ref` file on the orphan branch to avoid redundant runs.
+  resolve-ref:
+    name: Resolve EDS ref
+    runs-on: ubuntu-latest
+    outputs:
+      eds_ref: ${{ steps.resolve.outputs.eds_ref }}
+      skip: ${{ steps.resolve.outputs.skip }}
+      environment: ${{ steps.resolve.outputs.environment }}
+    steps:
+      # For dispatch: pass through the user-provided ref.
+      # For cron: find the latest eds-core-react release tag from equinor/design-system,
+      # then read .eds-ref from the eds-content branch to see if we already indexed it.
+      # Outputs skip=true when the release hasn't changed since last run.
+      - name: Resolve ref and check skip
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_EDS_REF: ${{ inputs.eds_ref }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "eds_ref=${INPUT_EDS_REF}" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "environment=${INPUT_ENVIRONMENT}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual dispatch — building EDS ref: ${INPUT_EDS_REF}"
+            exit 0
+          fi
+
+          # Scheduled run: find the latest @equinor/eds-core-react release
+          latest_tag=$(gh release list -R "$EDS_REPO" --limit 50 \
+            --json tagName \
+            --jq '[.[] | select(.tagName | startswith("@equinor/eds-core-react@"))][0].tagName // empty')
+
+          if [[ -z "$latest_tag" ]]; then
+            echo "::warning::No @equinor/eds-core-react release found"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::notice::Latest EDS release: ${latest_tag}"
+
+          # Compare against the last-indexed ref stored in .eds-ref on the orphan branch
+          last_indexed=$(gh api "repos/${{ github.repository }}/contents/.eds-ref?ref=eds-content" \
+            --jq '.content' 2>/dev/null | base64 -d | tr -d '\n') || true
+
+          if [[ -n "$last_indexed" && "$latest_tag" == "$last_indexed" ]]; then
+            echo "::notice::EDS ref ${latest_tag} already indexed — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "eds_ref=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "environment=docs" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        if: steps.resolve.outputs.skip != 'true'
+        run: |
+          echo "### EDS ref: ${{ steps.resolve.outputs.eds_ref }}" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Build EDS content via Docker ───────────────────────────────────────────
+  # Runs eds/docker/Dockerfile which:
+  #   Stage 1 (build)     — clones equinor/design-system at the resolved ref,
+  #                         installs deps, builds tokens + icons + Storybook
+  #   Stage 2 (extractor) — runs storybook-llms-extractor to extract component
+  #                         docs from the Storybook build as markdown
+  #   Stage 3 (process)   — converts token JSON → markdown tables, trims noisy
+  #                         story extractions, removes empty skeleton pages
+  #   Stage 4 (export)    — collects final markdown files from all stages
+  #
+  # Output is a flat directory of ~175 markdown files covering components,
+  # design tokens, foundation docs, and icon references.
+  build-eds:
+    name: Build EDS docs
+    needs: resolve-ref
+    if: needs.resolve-ref.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      # Uses BuildKit cache (GHA backend) so unchanged stages are not rebuilt.
+      # The `export` target outputs plain files (scratch-based) for artifact upload.
+      - name: Build EDS and extract docs
+        uses: docker/build-push-action@v7
+        with:
+          context: ./eds/docker
+          file: eds/docker/Dockerfile
+          target: export
+          outputs: type=local,dest=eds-content
+          build-args: |
+            EDS_REF=${{ needs.resolve-ref.outputs.eds_ref }}
+          cache-from: type=gha,scope=eds-build
+          cache-to: type=gha,scope=eds-build,mode=max
+
+      # Sanity check: if the Docker build produced zero markdown files,
+      # something went wrong upstream (bad EDS ref, build failure, etc.).
+      - name: Verify output
+        run: |
+          set -euo pipefail
+          count=$(find eds-content -name '*.md' | wc -l)
+          echo "::notice::Extracted ${count} markdown files"
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::No markdown files extracted — aborting"
+            exit 1
+          fi
+
+      # Artifact is consumed by the index-eds job. Retained for 7 days
+      # so maintainers can inspect the extracted content if indexing fails.
+      - name: Upload extracted docs
+        uses: actions/upload-artifact@v7
+        with:
+          name: eds-docs
+          path: eds-content/
+          retention-days: 7
+
+  # ── Index EDS content to Azure AI Search ───────────────────────────────────
+  # This job implements diff-based indexing:
+  #   1. Fetches the previous content snapshot from the `eds-content` orphan branch
+  #   2. Downloads the freshly built content on top
+  #   3. Uses `git diff` to find exactly which files changed
+  #   4. Runs `ffc ai index add --diff --base-ref HEAD~1` so only changed files
+  #      get re-embedded (saves OpenAI API costs and indexing time)
+  #   5. Pushes the new snapshot to `eds-content` for the next run
+  #
+  # Permissions:
+  #   contents: write — needed to push the eds-content branch
+  #   id-token: write — needed for Azure OIDC federated credential login
+  index-eds:
+    name: Index EDS to search
+    needs: [resolve-ref, build-eds]
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-ref.outputs.environment }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/workflows/actions/node-setup
+
+      # Reads the index name (e.g. "eds-2026-03-14") from the config file
+      # for use in the ensure-index and summary steps.
+      - name: Read index name from config
+        id: index
+        run: |
+          index_name=$(node -e "import('$CONFIG_PATH').then(m => console.log(m.default.index.name))")
+          echo "name=${index_name}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Index name: ${index_name}"
+
+      # Creates a local git repo in eds-content/ and fetches the previous
+      # snapshot from the `eds-content` orphan branch. This becomes HEAD.
+      # After downloading new content, we commit on top — `git diff HEAD~1`
+      # then shows exactly what files were added, modified, or deleted.
+      #
+      # First run (no orphan branch): creates an empty commit so the CLI's
+      # HEAD~1 comparison works. The indexer will process all files.
+      - name: Initialize eds-content with history
+        id: content
+        env:
+          EDS_REF: ${{ needs.resolve-ref.outputs.eds_ref }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p eds-content
+          cd eds-content
+          git init
+          git config user.name "eds-indexer[bot]"
+          git config user.email "eds-indexer[bot]@users.noreply.github.com"
+
+          # Try to fetch the previous content snapshot from the orphan branch
+          has_previous=false
+          if git fetch origin eds-content --depth=1 2>/dev/null; then
+            git reset FETCH_HEAD
+            git checkout -- .
+            git add -A && git commit --allow-empty -m "previous snapshot" || true
+            has_previous=true
+          else
+            echo "::notice::No previous eds-content branch — first run, full index"
+            # Create an empty initial commit so HEAD~1 works after the next commit
+            git commit --allow-empty -m "initial (empty)"
+          fi
+
+          echo "has_previous=${has_previous}" >> "$GITHUB_OUTPUT"
+
+      # Overlay the freshly built content on top of the previous snapshot.
+      # New/modified files replace old ones; deleted files remain only in git history.
+      - name: Download new content
+        uses: actions/download-artifact@v8
+        with:
+          name: eds-docs
+          path: eds-content/
+
+      # Stage all changes and check if anything actually differs.
+      # If content is identical (e.g. EDS released a fix that didn't change docs),
+      # skip indexing entirely to avoid unnecessary API calls.
+      - name: Commit new content and detect changes
+        id: diff
+        working-directory: eds-content
+        env:
+          EDS_REF: ${{ needs.resolve-ref.outputs.eds_ref }}
+        run: |
+          set -euo pipefail
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No content changes detected — nothing to index"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            changed=$(git diff --cached --name-status | wc -l)
+            echo "::notice::${changed} files changed since last index"
+            git diff --cached --stat
+            echo "${EDS_REF}" > .eds-ref
+            git add .eds-ref
+            git commit -m "eds-content: ${EDS_REF}"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Only authenticate when we actually need to talk to Azure.
+      # Uses OIDC federated credentials — no secrets stored in the repo.
+      - name: Azure login (OIDC)
+        if: steps.diff.outputs.has_changes == 'true' || inputs.clean
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.FUSION_AI_SP_CLIENT_ID }}
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      # Idempotent: creates the Azure AI Search index if it doesn't exist,
+      # or validates the schema matches if it does. Safe to run every time.
+      - name: Ensure index exists
+        if: steps.diff.outputs.has_changes == 'true' || inputs.clean
+        env:
+          FUSION_ENV: ${{ vars.FUSION_ENV }}
+        run: pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index create --env "$FUSION_ENV" --config "$CONFIG_PATH"
+
+      # Three modes:
+      #   --clean (manual dispatch): wipes all existing embeddings, re-indexes everything
+      #   --diff (has previous snapshot): only embeds changed files, deletes removed ones
+      #   full (first run): indexes all documents without diffing
+      - name: Index changed EDS docs
+        if: steps.diff.outputs.has_changes == 'true' || inputs.clean
+        timeout-minutes: 10
+        working-directory: eds-content
+        env:
+          INPUT_CLEAN: ${{ inputs.clean }}
+          FUSION_ENV: ${{ vars.FUSION_ENV }}
+          HAS_PREVIOUS: ${{ steps.content.outputs.has_previous }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${INPUT_CLEAN:-false}" == "true" ]]; then
+            echo "::notice::Clean rebuild — re-indexing all documents"
+            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --clean --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+          elif [[ "$HAS_PREVIOUS" == "true" ]]; then
+            echo "::notice::Incremental index — processing only changed files"
+            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --diff --base-ref HEAD~1 --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+          else
+            echo "::notice::First run — indexing all documents"
+            pnpm --filter @equinor/fusion-react-eds-index exec ffc ai index add --env "$FUSION_ENV" --config "../$CONFIG_PATH"
+          fi
+
+      # Persist the current content as the baseline for the next run.
+      # Force-push is safe here — the orphan branch has no PR/review workflow,
+      # it's purely a content snapshot used for diffing.
+      - name: Push content snapshot to orphan branch
+        if: steps.diff.outputs.has_changes == 'true' && success()
+        working-directory: eds-content
+        run: |
+          git push origin HEAD:refs/heads/eds-content --force
+
+      - name: Execution summary
+        if: always()
+        env:
+          EDS_REF: ${{ needs.resolve-ref.outputs.eds_ref }}
+          EXECUTION_STATUS: ${{ job.status }}
+          SEARCH_INDEX_NAME: ${{ steps.index.outputs.name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EXECUTION_STATUS" == "success" ]]; then
+            outcome="Indexing completed successfully."
+          else
+            outcome="Indexing failed — eds-content branch was not updated."
+          fi
+
+          {
+            echo '# EDS Index Summary'
+            echo
+            echo "$outcome"
+            echo
+            echo '| Detail | Value |'
+            echo '|--------|-------|'
+            echo "| EDS ref | \`${EDS_REF}\` |"
+            echo "| Index | \`${SEARCH_INDEX_NAME}\` |"
+            echo "| Status | ${EXECUTION_STATUS} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/eds/.gitignore
+++ b/eds/.gitignore
@@ -1,0 +1,6 @@
+# Generated content (built via Docker pipeline)
+/content/
+
+# Bun tooling output
+/tokens/
+/stories/

--- a/eds/docker/Dockerfile
+++ b/eds/docker/Dockerfile
@@ -1,0 +1,92 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# EDS Content Extraction Pipeline
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Multi-stage Docker build that extracts indexable markdown content from the
+# Equinor Design System (equinor/design-system) repository.
+#
+# Stages:
+#   1. build     — clone EDS repo, install deps, build Storybook + tokens
+#   2. extractor — extract component docs from Storybook via llms-extractor
+#   3. process   — convert token JSON → markdown, trim/patch extracted docs
+#   4. export    — collect final markdown files (scratch-based, for artifact upload)
+#
+# Build args:
+#   EDS_REPO — git URL of the design-system repo (default: equinor/design-system)
+#   EDS_REF  — git ref to build: tag, branch, or SHA (default: main)
+#
+# Usage (from repo root):
+#   docker build -f eds/docker/Dockerfile -t eds-content ./eds/docker \
+#     --build-arg EDS_REF=@equinor/eds-core-react@0.46.0 \
+#     --target export --output type=local,dest=eds-content
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Stage 1: Build Storybook ────────────────────────────────────────────────
+# Clones equinor/design-system at the requested ref, installs dependencies,
+# and builds the full Storybook bundle (tokens → icons → core-react → storybook).
+# This is the slowest stage; BuildKit layer caching keeps it fast across reruns
+# when the EDS ref hasn't changed.
+FROM node:24-alpine AS build
+
+RUN apk add --no-cache git
+RUN npm install -g pnpm@10.15.0
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+WORKDIR /app
+
+ARG EDS_REPO=https://github.com/equinor/design-system.git
+ARG EDS_REF=main
+RUN git clone --depth 1 --branch "${EDS_REF}" "${EDS_REPO}" .
+
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm build:tokens-build \
+    && pnpm build:icons \
+    && pnpm build:tokens \
+    && pnpm build:utils \
+    && pnpm build:core-react \
+    && pnpm build:storybook
+
+# ── Stage 2: Extract component docs ─────────────────────────────────────────
+# Runs storybook-llms-extractor (Playwright-based) against the Storybook build
+# to produce one markdown file per component. Tools are installed before
+# copying build output so the layer is cached independently.
+FROM node:24-bookworm AS extractor
+
+WORKDIR /app
+RUN npm install @fluentui/storybook-llms-extractor@0.0.4
+RUN npx playwright install --with-deps chromium
+
+COPY --from=build /app/packages/eds-core-react/storybook-build ./storybook-build
+RUN npx storybook-llms-extractor --distPath ./storybook-build
+RUN cd ./storybook-build/llms && for f in *.txt; do mv "$f" "${f%.txt}.md"; done
+
+# ── Stage 3: Post-process extracted content ──────────────────────────────────
+# Runs three Bun scripts (from the build context) that clean up the output:
+#   convert-tokens.ts — token JSON → markdown tables with CSS variable refs
+#   trim-stories.ts   — remove empty prop sections, beta duplicates, blank runs
+#   fix-index-gaps.ts — remove skeleton pages, prepend import lines
+FROM oven/bun:slim AS process
+
+WORKDIR /app
+COPY . .
+
+COPY --from=build /app/packages/eds-tokens/build/json ./json
+COPY --from=extractor /app/storybook-build/llms/ ./stories
+COPY --from=build /app/apps/design-system-docs/docs/components ./components
+
+RUN bun run convert-tokens.ts
+RUN bun run trim-stories.ts
+RUN bun run fix-index-gaps.ts /app
+
+# ── Stage 4: Collect final output ───────────────────────────────────────────
+# scratch-based stage that contains only the processed markdown files.
+# Use `--target export --output type=local,dest=<dir>` to extract them.
+FROM scratch AS export
+COPY --from=process /app/components /components
+COPY --from=build /app/apps/design-system-docs/docs/foundation /foundation
+COPY --from=process /app/stories/ /stories
+COPY --from=process /app/tokens/ /tokens
+COPY --from=build /app/packages/eds-tokens/README.md /tokens/eds-tokens.md
+COPY --from=build /app/packages/eds-icons/README.md /tokens/eds-icons.md

--- a/eds/docker/convert-tokens.ts
+++ b/eds/docker/convert-tokens.ts
@@ -1,0 +1,81 @@
+const out = './tokens';
+await Bun.$`mkdir -p ${out}`.quiet();
+
+type TokenMap = Record<string, string | number>;
+
+/** Read and parse a JSON token file. */
+const readTokens = (file: string): Promise<TokenMap> => Bun.file(file).json();
+
+/** Convert a flat { key: value } token JSON file into a markdown table. */
+async function convert(file: string, title: string, prefix: string, unit = ''): Promise<string> {
+  const tokens = await readTokens(file);
+  const rows = Object.entries(tokens).map(([key, val]) => {
+    const cssVar = `${prefix}${key}`;
+    const display = typeof val === 'number' ? `${val}${unit}` : val;
+    return `| \`${cssVar}\` | \`${display}\` |`;
+  });
+  return `# ${title}\n\nInstall: \`pnpm install @equinor/eds-tokens\`\nImport: \`@import '@equinor/eds-tokens/css/variables';\`\n\n| CSS Variable | Value |\n|---|---|\n${rows.join('\n')}\n`;
+}
+
+// Color tokens — static semantic (light theme, explicit category in var name)
+await Bun.write(
+  `${out}/color-tokens-light.md`,
+  await convert(
+    'json/color/static/flat/semantic.json',
+    'EDS Color Tokens — Light Theme (Static Semantic)',
+    '--eds-color-',
+  ),
+);
+
+// Color tokens — dark scheme
+await Bun.write(
+  `${out}/color-tokens-dark.md`,
+  await convert(
+    'json/color/color-scheme/flat/dark-semantic.json',
+    'EDS Color Tokens — Dark Theme',
+    '--eds-color-',
+  ),
+);
+
+// Spacing tokens — both density modes
+await Bun.write(
+  `${out}/spacing-tokens-spacious.md`,
+  await convert(
+    'json/spacing/flat/spacious.json',
+    'EDS Spacing & Sizing Tokens — Spacious Density',
+    '--eds-',
+    'px',
+  ),
+);
+
+await Bun.write(
+  `${out}/spacing-tokens-comfortable.md`,
+  await convert(
+    'json/spacing/flat/comfortable.json',
+    'EDS Spacing & Sizing Tokens — Comfortable Density',
+    '--eds-',
+    'px',
+  ),
+);
+
+// Dynamic color tokens (per-category, used with data-color-appearance)
+const categories = ['accent', 'neutral', 'success', 'info', 'warning', 'danger'] as const;
+const dynamicRows = (
+  await Promise.all(
+    categories.map(async (cat) => {
+      const tokens = await readTokens(`json/color/dynamic/flat/semantic-${cat}.json`);
+      const heading = `## ${cat.charAt(0).toUpperCase() + cat.slice(1)} (\`data-color-appearance="${cat}"\`)\n`;
+      const rows = Object.entries(tokens).map(
+        ([key, val]) => `| \`--eds-color-${key}\` | \`${val}\` |`,
+      );
+      return `${heading}\n| CSS Variable | Value |\n|---|---|\n${rows.join('\n')}`;
+    }),
+  )
+).join('\n\n');
+
+await Bun.write(
+  `${out}/color-tokens-dynamic.md`,
+  `# EDS Dynamic Color Tokens\n\nThese tokens resolve per semantic category set via \`data-color-appearance\` on a parent element.\nThe CSS variable names omit the category — the attribute controls which palette is active.\n\nInstall: \`pnpm install @equinor/eds-tokens\`\nImport: \`@import '@equinor/eds-tokens/css/variables';\`\n\n${dynamicRows}\n`,
+);
+
+console.log('Token markdown generated:', out);

--- a/eds/docker/fix-index-gaps.ts
+++ b/eds/docker/fix-index-gaps.ts
@@ -1,0 +1,157 @@
+/**
+ * fix-index-gaps.ts — Patch EDS index output to close eval gaps
+ *
+ * 1. Remove empty component skeleton pages (only headings + empty sections)
+ * 2. Prepend an import one-liner to each story extraction
+ *
+ * Safe to re-run: each step is idempotent.
+ *
+ * Usage: bun run eds/fix-index-gaps.ts
+ */
+import { readdir, readFile, writeFile, unlink, rm } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+
+const BASE_DIR = process.argv[2] ?? join(import.meta.dirname, 'out');
+const COMPONENTS_DIR = join(BASE_DIR, 'components');
+const STORIES_DIR = join(BASE_DIR, 'stories');
+const ASSETS_DIR = join(COMPONENTS_DIR, 'assets');
+
+// ─── 1. Remove empty component skeleton pages ──────────────────────────────
+
+/** Returns true if the file is an empty skeleton (only headings, frontmatter,
+ *  admonition fences, bare list markers, bold markers, and whitespace). */
+function isEmpty(content: string): boolean {
+  const stripped = content
+    .replace(/^---[\s\S]*?^---/m, '') // frontmatter
+    .replace(/^#.*$/gm, '') // headings
+    .replace(/^:::.*/gm, '') // admonition fences
+    .replace(/^- *$/gm, '') // bare list markers
+    .replace(/^\*\*.*$/gm, '') // bold markers
+    .replace(/\s+/g, ''); // all whitespace
+  return stripped.length === 0;
+}
+
+async function collectMdFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries: Awaited<ReturnType<typeof readdir>>;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await collectMdFiles(full)));
+    } else if (entry.name.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+async function removeEmptySkeletons(): Promise<void> {
+  console.log('=== Step 1: Remove empty component skeleton pages ===');
+  const files = await collectMdFiles(COMPONENTS_DIR);
+  let removed = 0;
+  let kept = 0;
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8');
+    if (isEmpty(content)) {
+      console.log(`  REMOVE: ${file}`);
+      await unlink(file);
+      removed++;
+    } else {
+      kept++;
+    }
+  }
+
+  console.log(`  Removed: ${removed} | Kept: ${kept}\n`);
+}
+
+// ─── 2. Prepend import one-liner to story extractions ───────────────────────
+
+/** Overrides where the story heading name differs from the eds-core-react export. */
+const IMPORT_OVERRIDES: Record<string, string> = {
+  Chips: 'Chip',
+  Lists: 'List',
+  Circular: 'Progress',
+  Dots: 'Progress',
+  Linear: 'Progress',
+  Star: 'Progress',
+  Preview: 'Icon',
+  Group: 'Button',
+  Toggle: 'Button',
+  Heading: 'Typography',
+  Paragraph: 'Typography',
+  TypographyNext: 'Typography',
+};
+
+/** Headings that don't map to a component import. */
+const SKIP_HEADINGS = new Set([
+  '# Equinor Design System Storybook',
+  '# Playground/Examples',
+  '# @equinor/utils',
+  '# Foundation/Spacing',
+  '# Icons', // preview page, no heading slash
+]);
+
+function getImportName(heading: string): string | null {
+  if (SKIP_HEADINGS.has(heading.trim())) return null;
+
+  // Extract last path segment: "# Category/Sub/Component" → "Component"
+  const withoutHash = heading.replace(/^#\s*/, '');
+  const segments = withoutHash.split('/');
+  const component = segments[segments.length - 1].trim();
+
+  return IMPORT_OVERRIDES[component] ?? component;
+}
+
+async function prependImportLines(): Promise<void> {
+  console.log('=== Step 2: Prepend import line to story files ===');
+  const entries = await readdir(STORIES_DIR);
+  let patched = 0;
+  let skipped = 0;
+
+  for (const name of entries) {
+    if (!name.endsWith('.md')) continue;
+    const file = join(STORIES_DIR, name);
+    const content = await readFile(file, 'utf-8');
+
+    // Already patched?
+    if (content.includes('@equinor/eds-core-react')) {
+      skipped++;
+      continue;
+    }
+
+    const heading = content.split('\n')[0];
+    const importName = getImportName(heading);
+
+    if (!importName) {
+      console.log(`  SKIP (non-component): ${basename(file)}`);
+      skipped++;
+      continue;
+    }
+
+    const importLine = `> **Package:** \`@equinor/eds-core-react\` — \`import { ${importName} } from '@equinor/eds-core-react'\``;
+
+    // Insert import line after the heading (line 1)
+    const lines = content.split('\n');
+    const patched_content = [lines[0], '', importLine, ...lines.slice(1)].join('\n');
+    await writeFile(file, patched_content);
+
+    console.log(`  PATCH: ${basename(file)} → import { ${importName} }`);
+    patched++;
+  }
+
+  console.log(`  Patched: ${patched} | Skipped: ${skipped}\n`);
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+await rm(ASSETS_DIR, { recursive: true, force: true });
+console.log(`Removed assets directory: ${ASSETS_DIR}`);
+await removeEmptySkeletons();
+await prependImportLines();
+console.log('=== Done ===');

--- a/eds/docker/trim-stories.ts
+++ b/eds/docker/trim-stories.ts
@@ -1,0 +1,73 @@
+import { Glob } from 'bun';
+import { unlink } from 'node:fs/promises';
+
+const dir = './stories';
+
+/** Remove empty `## Props` / `#### Props` sections (heading + optional blank lines, no table). */
+function trimEmptyPropsSections(content: string): string {
+  return content.replace(/^#{2,4} Props\n\n+(?=#{|$|\n*$)/gm, '');
+}
+
+/** Remove subcomponent blocks that have only a heading and an empty Props section. */
+function trimEmptySubcomponents(content: string): string {
+  return content.replace(/^### [^\n]+\n\n+#### Props\n\n+(?=###|\s*$)/gm, '');
+}
+
+/** Remove bare `### Name` headings with no content before the next heading or end of file. */
+function trimEmptyHeadings(content: string): string {
+  return content.replace(/^### [^\n]+\n\n+(?=#{2,3} |\s*$)/gm, '');
+}
+
+/** Remove a `## Subcomponents` section that has no remaining content. */
+function trimEmptySubcomponentsSection(content: string): string {
+  return content.replace(/^## Subcomponents\n\n+(?=## |\s*$)/gm, '');
+}
+
+/** Remove prop table rows where both Default and Description columns are empty. */
+function trimEmptyPropRows(content: string): string {
+  return content.replace(/^\|[^|]+\|[^|]+\|[^|]+\|\s+\|\s+\|\s*$/gm, '');
+}
+
+/** Remove bracket-only links with no display text, e.g. `[](iframe.html?...)`. */
+function trimEmptyLinks(content: string): string {
+  return content.replace(/^\[\]\([^)]+\)\s*$/gm, '');
+}
+
+/** Collapse runs of 3+ blank lines down to 2. */
+function collapseBlankLines(content: string): string {
+  return content.replace(/\n{3,}/g, '\n\n');
+}
+
+const glob = new Glob('*.md');
+let processed = 0;
+let deleted = 0;
+
+for await (const file of glob.scan(dir)) {
+  const path = `${dir}/${file}`;
+
+  // Remove beta component files — duplicates of stable docs with unstable APIs
+  if (file.startsWith('eds-2-0-beta-')) {
+    await unlink(path);
+    deleted++;
+    continue;
+  }
+
+  let content = await Bun.file(path).text();
+  const before = content.length;
+
+  content = trimEmptySubcomponents(content);
+  content = trimEmptyHeadings(content);
+  content = trimEmptySubcomponentsSection(content);
+  content = trimEmptyPropsSections(content);
+  content = trimEmptyPropRows(content);
+  content = trimEmptyLinks(content);
+  content = collapseBlankLines(content);
+  content = content.trimEnd() + '\n';
+
+  if (content.length !== before) {
+    await Bun.write(path, content);
+    processed++;
+  }
+}
+
+console.log(`Deleted ${deleted} beta files, trimmed ${processed} story files`);

--- a/eds/eval/README.md
+++ b/eds/eval/README.md
@@ -1,0 +1,54 @@
+# EDS Evaluation Index
+
+Evaluation infrastructure for validating EDS (Equinor Design System) search retrieval quality in the dedicated EDS index. Domain files in this directory define expected search queries and what the index should return for each.
+
+## How it works
+
+Each **domain file** lists search queries as `##` headings. Under each heading, bullet points describe what the index **must** or **should** return. When evaluating, run the heading as a search query against the EDS index and check results against the expectations.
+
+## Directory structure
+
+```
+eval/
+  eds/
+    README.md            # This file
+    components.md        # Input, feedback, navigation, surface, data-display components
+    tokens.md            # Color tokens (light/dark), spacing, sizing, elevation
+    icons.md             # Icon discovery, import patterns, categories
+    foundation.md        # Colour system, accessibility, typography, design patterns
+    getting-started.md   # Installation, EdsProvider, package structure
+```
+
+## Format
+
+Each domain file follows the same structure as `eval/index/`:
+
+```markdown
+# Domain Name
+
+Judgement instructions for this domain.
+
+## Search query as a natural question
+
+- must mention X
+- must show Y pattern
+- should reference Z
+```
+
+### Requirement levels
+
+- **`must`** — the index must surface this for the query; absence means a gap
+- **`should`** — the index should ideally surface this; absence is not critical
+
+## Index details
+
+- **Index name**: `eds-2026-03-14`
+- **Embedding model**: `text-embedding-3-large`
+- **Content sources**: Storybook-extracted docs (64), doc-site pages (104), token/icon references (7)
+- **Config**: `fusion-ai.config.eds.ts`
+
+## How to contribute
+
+1. Pick the right domain file
+2. Add a `##` heading phrased as a natural question developers would search for
+3. Add `must` and `should` bullets for what the index should return

--- a/eds/eval/components.md
+++ b/eds/eval/components.md
@@ -1,0 +1,80 @@
+# Components
+
+These queries test whether the EDS index surfaces accurate component documentation
+when developers ask about EDS React component usage, props, patterns, and examples.
+
+When judging results, verify that:
+- Results reference `@equinor/eds-core-react` as the component package.
+- Props tables include correct prop names, types, and defaults — not invented values.
+- Code examples use the correct import path and valid JSX patterns.
+- Component guidelines (do/don't, accessibility) are surfaced alongside props when available.
+- Subcomponent composition patterns (e.g., `Dialog.Header`, `Accordion.Item`) are shown accurately.
+
+## How to use the Button component with different variants and colors
+
+- must mention `Button` from `@equinor/eds-core-react`
+- must list the `variant` prop with values including `contained`, `outlined`, `ghost`
+- must list the `color` prop with values `primary`, `secondary`, `danger`
+- must show a code example with Button JSX
+- should mention `href` prop for link-style buttons
+- should mention `fullWidth` prop
+
+## How to open and close a Dialog modal in EDS
+
+- must mention `Dialog` from `@equinor/eds-core-react`
+- must show the `open` prop as required for controlling dialog visibility
+- must mention `onClose` callback for handling close events
+- must mention `isDismissable` prop for ESC key and outside-click dismissal
+- should show subcomponent composition: `Dialog.Header`, `Dialog.Title`, `Dialog.CustomContent`, `Dialog.Actions`
+- should include a code example showing controlled open/close state
+
+## How to use Accordion with controlled expand state
+
+- must mention `Accordion` from `@equinor/eds-core-react`
+- must mention `Accordion.Item` subcomponent with `isExpanded` prop
+- must mention `onExpandedChange` callback for controlled state
+- must show `chevronPosition` prop with `left` and `right` options
+- should mention `headerLevel` prop for semantic heading levels
+- should mention `disabled` prop on `Accordion.Item`
+
+## How to use Tabs for navigation in EDS
+
+- must mention `Tabs` from `@equinor/eds-core-react`
+- must show `Tabs.List` and `Tabs.Tab` subcomponent pattern
+- must mention `activeTab` and `onChange` for controlled tab switching
+- should show `Tabs.Panels` and `Tabs.Panel` for content panels
+- should mention `variant` prop for tab styling options
+
+## How to show a Snackbar notification in EDS
+
+- must mention `Snackbar` from `@equinor/eds-core-react`
+- must show `open` prop for controlling visibility
+- must mention `onClose` callback
+- must mention `autoHideDuration` for auto-dismiss timing
+- should show action button pattern inside Snackbar
+- should mention placement and stacking behavior
+
+## How to use Autocomplete with search and selection in EDS
+
+- must mention `Autocomplete` from `@equinor/eds-core-react`
+- must show `options` prop for providing selectable items
+- must mention `onOptionsChange` callback for handling selection
+- must mention `label` prop
+- should mention `multiple` prop for multi-select
+- should mention `optionLabel` for custom display text
+
+## How to create a Card layout in EDS
+
+- must mention `Card` from `@equinor/eds-core-react`
+- must show subcomponent composition: `Card.Header`, `Card.Content`, `Card.Actions`
+- must mention `variant` prop with `default`, `info`, `warning`, `danger`
+- should show `Card.HeaderTitle` for title content
+- should show `Card.Media` for image/media content
+
+## How to use the SideSheet component in EDS
+
+- must mention `SideSheet` from `@equinor/eds-core-react`
+- must show `open` prop for controlling visibility
+- must mention `onClose` callback
+- should mention `variant` prop for different side sheet sizes
+- should show content composition pattern with header and body

--- a/eds/eval/foundation.md
+++ b/eds/eval/foundation.md
@@ -1,0 +1,56 @@
+# Foundation
+
+These queries test whether the EDS index surfaces design foundation knowledge
+— colour system architecture, spacing guidelines, typography rules, accessibility,
+and design patterns that guide consistent interface construction.
+
+When judging results, verify that:
+- Colour system results reference semantic categories (accent, neutral, success, danger, warning, info), not raw hex values alone.
+- Spacing results reference the 8px grid system and named spacer sizes (XX Small through XXX Large).
+- Typography results reference EDS heading and paragraph components or typographic guidelines.
+- Accessibility results reference EDS-specific guidance, not generic WCAG summaries.
+- Results come from doc-site foundation pages, not just component stories.
+
+## How does the EDS colour system work with light and dark themes
+
+- must mention semantic colour categories: accent, neutral, success, danger, warning, info
+- must mention that colours are organised by role/purpose, not by shade
+- must mention light and dark colour scheme support
+- should mention `data-color-scheme` or `data-color-appearance` attribute for theme switching
+- should reference the colour palette generator tool
+- should mention that colour steps are designed for intentional contrast, not linear gradients
+
+## What spacing scale does EDS use and how to apply it
+
+- must mention the 8px increment base scale
+- must list named spacer sizes: XX Small, X Small, Small, Medium, Large, X Large, XX Large, XXX Large
+- must mention that XX Small and X Small are only for use inside components
+- should reference the spacing foundation documentation
+- should mention comfortable and spacious density modes
+
+## How to set up typography with EDS heading and paragraph components
+
+- must mention `Typography` or `Heading` or `Paragraph` from `@equinor/eds-core-react`
+- must show heading level props or variant options
+- should mention the Equinor font family
+- should reference the typography foundation documentation for font sizes and line heights
+
+## What accessibility guidelines does EDS provide for components
+
+- must reference EDS accessibility documentation or guidelines
+- must mention accessible colour combinations and contrast requirements
+- should mention ARIA patterns or keyboard navigation for EDS components
+- should mention that accessibility is a core principle of the colour system
+
+## What design patterns does EDS recommend for consistent interfaces
+
+- must reference the EDS patterns or guidelines documentation
+- must mention at least one pattern category (layout, interaction, or composition)
+- should reference the do/don't guidelines available in component documentation
+
+## How to use EDS elevation and shape tokens for visual hierarchy
+
+- must reference elevation or shape documentation from the design tokens foundation
+- must mention at least one elevation or shape concept (shadows, border-radius, or z-index)
+- should reference `@equinor/eds-tokens` for token values
+- should mention how elevation creates visual hierarchy in interfaces

--- a/eds/eval/getting-started.md
+++ b/eds/eval/getting-started.md
@@ -1,0 +1,49 @@
+# Getting Started
+
+These queries test whether the EDS index surfaces onboarding and setup information
+— installing packages, wrapping apps with EdsProvider, understanding the package
+structure, and integrating EDS with development workflows.
+
+When judging results, verify that:
+- Installation instructions use `@equinor/eds-core-react` as the primary component package.
+- EdsProvider is mentioned as the required wrapper for EDS components.
+- Package names are real published packages, not fabricated.
+- Figma and design tool references come from actual doc-site content, not hallucinated.
+
+## How to install and get started with EDS in a React project
+
+- must mention `@equinor/eds-core-react` as the main component package to install
+- must mention `@equinor/eds-tokens` for design tokens
+- must mention `@equinor/eds-icons` for icon data
+- should mention `EdsProvider` as the top-level wrapper
+- should show a basic installation command using npm or pnpm
+
+## What is EdsProvider and how to set it up
+
+- must mention `EdsProvider` from `@equinor/eds-core-react`
+- must explain that it provides density and theme context to child components
+- should show a code example wrapping an app with `EdsProvider`
+- should mention density options (comfortable, spacious)
+
+## What packages make up the Equinor Design System
+
+- must mention `@equinor/eds-core-react` for React components
+- must mention `@equinor/eds-tokens` for design tokens and CSS variables
+- must mention `@equinor/eds-icons` for icon data
+- should mention `@equinor/eds-utils` if it exists in the index
+- should reference the EDS GitHub repository at `equinor/design-system`
+
+## How to set up EDS in Figma for design work
+
+- must reference Figma-related content from the EDS documentation
+- must mention the Figma component library or getting started guide for designers
+- should mention team roles (designer vs developer onboarding paths)
+- should reference the EDS doc-site for detailed Figma setup instructions
+
+## What is the Equinor Design System and what does it provide
+
+- must describe EDS as a design system for Equinor's digital products
+- must mention that it provides React components, design tokens, and icons
+- must reference at least one key principle (consistency, accessibility, or Equinor branding)
+- should mention both the component library and the documentation site
+- should reference the colour foundation as a key feature

--- a/eds/eval/icons.md
+++ b/eds/eval/icons.md
@@ -1,0 +1,46 @@
+# Icons
+
+These queries test whether the EDS index surfaces useful information about EDS icons
+— finding icons by name or purpose, importing them, and using them in React.
+
+When judging results, verify that:
+- Icon names referenced are real exports from `@equinor/eds-icons`.
+- Import examples use the correct named export pattern.
+- React usage shows `Icon` component from `@equinor/eds-core-react` with `data` prop.
+- Results don't fabricate icon names that don't exist in the package.
+
+## How to import and use an EDS icon in React
+
+- must mention `@equinor/eds-icons` for icon data imports
+- must mention `Icon` component from `@equinor/eds-core-react`
+- must show the pattern: `import { save } from '@equinor/eds-icons'` and `<Icon data={save} />`
+- should mention that icons are imported as named exports (JavaScript objects, not SVG files)
+- should mention TypeScript 3.8+ requirement
+
+## What icon to use for delete or trash action
+
+- must reference an icon name from `@equinor/eds-icons` related to delete (e.g., `delete_to_trash`, `delete_forever`)
+- must show how to import it: `import { delete_to_trash } from '@equinor/eds-icons'`
+- should show React usage with `<Icon data={delete_to_trash} />`
+- should mention the icon category (action icons)
+
+## What warning or alert icons are available in EDS
+
+- must reference at least one warning-related icon from `@equinor/eds-icons` (e.g., `warning_filled`, `warning_outlined`, `error_filled`)
+- must show the import pattern for the icon
+- should mention multiple warning/alert icon variants
+- should show how to use with the `Icon` component
+
+## How to find and browse available EDS icons
+
+- must reference `@equinor/eds-icons` as the icon package
+- must mention that icons are available as named exports
+- should reference the EDS Storybook icon preview or icon documentation
+- should mention that the package contains system icons from the Equinor Design System
+
+## How to customize icon size and color in EDS
+
+- must mention the `Icon` component from `@equinor/eds-core-react`
+- must mention the `size` prop or CSS-based sizing for icons
+- should mention `color` prop or CSS color inheritance
+- should reference `--eds-sizing-icon-*` tokens for consistent icon sizing

--- a/eds/eval/tokens.md
+++ b/eds/eval/tokens.md
@@ -1,0 +1,54 @@
+# Tokens
+
+These queries test whether the EDS index surfaces accurate design token information
+when developers ask about CSS variables, color values, spacing, and sizing tokens.
+
+When judging results, verify that:
+- Returned CSS variable names are real `--eds-*` tokens, not invented names.
+- Token values match the actual theme (light vs dark) referenced in the query.
+- Results distinguish between light and dark theme tokens when relevant.
+- Spacing and sizing tokens reference the correct density mode (comfortable vs spacious).
+- Install and import instructions reference `@equinor/eds-tokens`.
+
+## What color token to use for a danger background
+
+- must return a CSS variable matching `--eds-color-bg-danger-*`
+- must show at least `--eds-color-bg-danger-surface` or `--eds-color-bg-danger-fill-emphasis-default`
+- must reference `@equinor/eds-tokens` as the source package
+- should distinguish between light and dark theme values
+- should mention related text token `--eds-color-text-danger-*` for pairing
+
+## How to use EDS spacing tokens for layout padding
+
+- must mention `--eds-spacing-*` CSS variables
+- must reference comfortable or spacious density modes
+- must mention `@equinor/eds-tokens` and the CSS import path
+- should show specific spacing variable examples like `--eds-spacing-comfortable-medium`
+- should mention the 8px increment base scale
+
+## What are the dark theme background color tokens in EDS
+
+- must return `--eds-color-bg-neutral-canvas` and `--eds-color-bg-neutral-surface` with dark theme values
+- must mention that dark theme tokens are in the dark color scheme
+- should list accent, success, warning, danger, and info background categories
+- should reference `@import '@equinor/eds-tokens/css/variables'` for CSS import
+
+## How to set icon sizes using EDS sizing tokens
+
+- must mention `--eds-sizing-icon-*` CSS variables
+- must show size scale from `xs` through `6xl` with pixel values
+- must reference `@equinor/eds-tokens` as the source
+- should mention that icon sizing tokens differ between comfortable and spacious density
+
+## What EDS tokens are available for elevation and shape
+
+- must mention elevation or shape-related tokens if they exist in the index
+- should reference the foundation design-tokens documentation for elevation and shape
+- should mention `--eds-sizing-stroke-thin` and `--eds-sizing-stroke-thick` for border tokens
+
+## How to import and use EDS CSS token variables in a project
+
+- must show `@import '@equinor/eds-tokens/css/variables'` or equivalent import path
+- must mention `pnpm install @equinor/eds-tokens` for installation
+- must show usage of CSS variables in styling (e.g., `var(--eds-color-bg-neutral-surface)`)
+- should mention that tokens support both light and dark themes via `data-color-scheme` or similar

--- a/eds/fusion-ai.config.eds.ts
+++ b/eds/fusion-ai.config.eds.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { defineIndexSchema } from '@equinor/fusion-framework-cli-plugin-ai-index';
+
+export default {
+  index: {
+    name: 'eds-2026-03-14',
+    model: 'text-embedding-3-large',
+    // File patterns to match for processing
+    patterns: [
+      '**/*.md',
+      // Exclude boilerplate endpoint/parameter generators that produce low-value embeddings
+      '!**/docs/README.md',
+      '!**/docs/about',
+      '!**/docs/resources',
+      '!**/docs/tone-guide',
+    ],
+    rawPatterns: ['**/*.md'],
+
+    // Promoted fields for direct OData filtering (see fusion-core-tasks#1011)
+    schema: defineIndexSchema({
+      shape: z.object({
+        type: z.string(),
+        tags: z.array(z.string()).default([]),
+      }),
+      resolve: (doc) => ({
+        type: (doc.metadata.attributes?.type as string) ?? 'markdown',
+        tags: (doc.metadata.attributes?.tags as string[]) ?? [],
+      }),
+    }),
+
+    // Metadata processing configuration
+    metadata: {
+      resolvePackage: false,
+      resolveGit: false,
+    },
+  },
+};

--- a/eds/fusion-cli.config.ts
+++ b/eds/fusion-cli.config.ts
@@ -1,0 +1,5 @@
+import aiIndexPlugin from '@equinor/fusion-framework-cli-plugin-ai-index';
+
+export default {
+  plugins: [aiIndexPlugin],
+};

--- a/eds/package.json
+++ b/eds/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@equinor/fusion-react-eds-index",
+  "version": "0.0.0",
+  "private": true,
+  "description": "EDS AI Search index infrastructure — config, content extraction tooling, and evaluation",
+  "type": "module",
+  "scripts": {
+    "docker:build": "docker build -f docker/Dockerfile -t eds-content docker",
+    "docker:extract": "docker build -f docker/Dockerfile -t eds-content docker --target export --output type=local,dest=content",
+    "index:create": "ffc ai index create --config ./fusion-ai.config.eds.ts",
+    "index:add": "ffc ai index add --config ./fusion-ai.config.eds.ts"
+  },
+  "dependencies": {
+    "@equinor/fusion-framework-cli": "^15.0.0",
+    "@equinor/fusion-framework-cli-plugin-ai-index": "^3.0.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "components"
   - "packages/*"
   - "storybook"
+  - "eds"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,3 @@ packages:
   - "components"
   - "packages/*"
   - "storybook"
-  - "eds"


### PR DESCRIPTION
## Summary

Moves the EDS AI Search index infrastructure from `equinor/fusion-framework` to this repo, making it self-contained alongside the components it documents.

## What's included

### `eds/` — index configuration
- `fusion-ai.config.eds.ts` — AI Search index schema (name, embedding model, file patterns, promoted fields)
- `fusion-cli.config.ts` — wires the `ai-index` CLI plugin
- `package.json` — private workspace package with docker/index scripts

### `eds/docker/` — content extraction pipeline
- `Dockerfile` — multi-stage build that clones `equinor/design-system`, builds Storybook, extracts component docs, converts tokens to markdown, and cleans up the output
- `convert-tokens.ts` — token JSON → markdown tables with CSS variable refs
- `trim-stories.ts` — removes empty prop sections, beta duplicates, blank runs
- `fix-index-gaps.ts` — removes skeleton pages, prepends import lines

### `eds/eval/` — search quality evaluation
- 6 files with search queries and expected results for validating index quality

### `.github/workflows/index-eds.yml` — CI workflow
Three jobs: **resolve-ref** → **build-eds** → **index-eds**

- Runs weekly (Monday 06:00 UTC) + manual dispatch
- Finds the latest `@equinor/eds-core-react` release and compares against `.eds-ref` on the `eds-content` orphan branch
- Builds content via Docker with BuildKit caching
- Diff-based indexing: only re-embeds changed files (saves OpenAI API costs)
- Supports clean rebuild via `workflow_dispatch`

### Other
- `pnpm-workspace.yaml` — added `eds` workspace entry

Closes #3159