### PR TITLE
Fix/filter/styling

### DIFF
--- a/.changeset/flat-lobsters-lie.md
+++ b/.changeset/flat-lobsters-lie.md
@@ -1,0 +1,7 @@
+---
+'@equinor/fusion-react-filter': patch
+---
+
+Fix filter panel layout and selected-count behavior in the filter header.
+
+This updates the selected counter to use an explicit numeric initial value and adjusts panel/container sizing styles so filters render with full-height layout and correct horizontal behavior.

--- a/packages/filter/src/components/filter/FilterOptionHeader.tsx
+++ b/packages/filter/src/components/filter/FilterOptionHeader.tsx
@@ -63,8 +63,10 @@ export const FilterOptionHeader = (props: FilterHeaderProps): ReactElement => {
   const { options$, selection$ } = useFilterOptionContext();
   const optionCount = Object.keys(useObservableState(options$).value || {}).length;
   const { value: selectedCount } = useObservableState(
-    useObservableSelector(selection$, (x) => (x ?? new Set()).size > 0),
+    useObservableSelector(selection$, (x) => (x ?? new Set()).size),
+    { initial: 0 },
   );
+
   const onIconClick = () => {
     if (showSearch) {
       setQuery('');
@@ -95,7 +97,7 @@ export const FilterOptionHeader = (props: FilterHeaderProps): ReactElement => {
       />
       <Styled.Header $showSearch={showSearch}>
         <span>{title}</span>
-        <Styled.Counter $noCount={!selectedCount}>
+        <Styled.Counter $noCount={selectedCount === 0}>
           <span>(</span>
           <span>{selectedCount}</span>
           <span>/</span>

--- a/packages/filter/src/components/misc/FilterContainer.tsx
+++ b/packages/filter/src/components/misc/FilterContainer.tsx
@@ -7,8 +7,9 @@ type SpacingKey = keyof typeof tokens.spacings.comfortable;
 const Styled = {
   Root: styled.div<{ $spacing?: SpacingKey }>`
     display: flex;
-    flex: auto;
     gap: ${({ $spacing }) => tokens.spacings.comfortable[$spacing || 'medium']};
+    height: 100%;
+    
     & > * {
       flex: 1;
     }

--- a/packages/filter/src/components/misc/FilterContainer.tsx
+++ b/packages/filter/src/components/misc/FilterContainer.tsx
@@ -6,7 +6,7 @@ type SpacingKey = keyof typeof tokens.spacings.comfortable;
 
 const Styled = {
   Root: styled.div<{ $spacing?: SpacingKey }>`
-    display: inline-flex;
+    display: flex;
     flex: auto;
     gap: ${({ $spacing }) => tokens.spacings.comfortable[$spacing || 'medium']};
     & > * {

--- a/packages/filter/src/components/panel/FilterPanel.tsx
+++ b/packages/filter/src/components/panel/FilterPanel.tsx
@@ -30,7 +30,6 @@ const Styled = {
   Filters: styled.div`
     overflow-x: auto;
     overflow-y: hidden;
-    display: flex;
     padding-bottom: calc(var(--filter-panel-spacing));
     margin-bottom: calc(var(--filter-panel-spacing) * -1);
     background-color: ${tokens.colors.ui.background__light.rgba};

--- a/packages/filter/src/components/panel/FilterPanelFilters.tsx
+++ b/packages/filter/src/components/panel/FilterPanelFilters.tsx
@@ -6,6 +6,12 @@ import { EdsProvider } from '@equinor/eds-core-react';
 
 import { map } from 'rxjs/operators';
 import { FilterContainer } from '../misc';
+import { styled } from 'styled-components';
+
+const FilterWrapper = styled.div<{ $showFilters: boolean }>`
+  display: ${({ $showFilters }) => ($showFilters ? 'block' : 'none')};
+  height: 100%;
+`;
 
 type FilterPanelFiltersProps = HTMLAttributes<HTMLDivElement> & {
   readonly FilterSelector?: FC;
@@ -28,10 +34,10 @@ export const FilterPanelFilters = (props: FilterPanelFiltersProps): ReactElement
   );
   return (
     <EdsProvider density="compact">
-      <div {...args} style={{ display: showFilters ? '' : 'none', height: '100%' }}>
+      <FilterWrapper {...args} $showFilters={Boolean(showFilters)}>
         {FilterSelector && <FilterSelector />}
         <FilterContainer>{filters}</FilterContainer>
-      </div>
+      </FilterWrapper>
     </EdsProvider>
   );
 };

--- a/packages/filter/src/components/panel/FilterPanelFilters.tsx
+++ b/packages/filter/src/components/panel/FilterPanelFilters.tsx
@@ -28,7 +28,7 @@ export const FilterPanelFilters = (props: FilterPanelFiltersProps): ReactElement
   );
   return (
     <EdsProvider density="compact">
-      <div {...args} style={{ display: showFilters ? '' : 'none' }}>
+      <div {...args} style={{ display: showFilters ? '' : 'none', height: '100%' }}>
         {FilterSelector && <FilterSelector />}
         <FilterContainer>{filters}</FilterContainer>
       </div>


### PR DESCRIPTION

Fix filter panel layout and selected-count behavior in the filter header.

This updates the selected counter to use an explicit numeric initial value and adjusts panel/container sizing styles so filters render with full-height layout and correct horizontal behavior.

Reference: https://github.com/equinor/fusion/issues/829