### PR TITLE
fix: update Storybook production build to preserve component names du…

### DIFF
--- a/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
+++ b/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
@@ -19,4 +19,4 @@ This combines two fixes:
 - Storybook Vite production build now preserves function and class names during minification.
 - React wrapper components created with `createComponent(...)` now set explicit `displayName` values across packages so runtime JSX serialization can keep meaningful names.
 
-Fixes #836
+Fixes [#836](https://github.com/equinor/fusion/issues/836)

--- a/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
+++ b/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
@@ -1,9 +1,22 @@
 ---
+"@equinor/fusion-react-date": patch
+"@equinor/fusion-react-list": patch
+"@equinor/fusion-react-markdown": patch
+"@equinor/fusion-react-person": patch
+"@equinor/fusion-react-ripple": patch
+"@equinor/fusion-react-searchable-dropdown": patch
+"@equinor/fusion-react-skeleton": patch
+"@equinor/fusion-react-textarea": patch
 "@equinor/fusion-react-components-stories": patch
 ---
 
-Fix Storybook production build to preserve component names
+Fix Storybook docs component names in production
 
-When Storybook is built for production, component names in code examples are no longer mangled during minification. This is achieved by configuring the Vite build to preserve function and class names through the Terser minifier.
+When Storybook is built for production, code examples now keep readable component names instead of showing generic values like `<no />`.
+
+This combines two fixes:
+
+- Storybook Vite production build now preserves function and class names during minification.
+- React wrapper components created with `createComponent(...)` now set explicit `displayName` values across packages so runtime JSX serialization can keep meaningful names.
 
 Fixes #836

--- a/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
+++ b/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
@@ -1,0 +1,9 @@
+---
+"@equinor/fusion-react-components-stories": patch
+---
+
+Fix Storybook production build to preserve component names
+
+When Storybook is built for production, component names in code examples are no longer mangled during minification. This is achieved by configuring the Vite build to preserve function and class names through the Terser minifier.
+
+Fixes #836

--- a/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
+++ b/.changeset/729315a7-09d0-4dd8-8199-2833fc7bb9ed.md
@@ -16,7 +16,7 @@ When Storybook is built for production, code examples now keep readable componen
 
 This combines two fixes:
 
-- Storybook Vite production build now preserves function and class names during minification.
-- React wrapper components created with `createComponent(...)` now set explicit `displayName` values across packages so runtime JSX serialization can keep meaningful names.
+- React wrapper components created with `createComponent(...)` now set explicit `displayName` values across packages so runtime JSX serialization uses meaningful names.
+- Storybook Vite production build sets `esbuild.keepNames: true` to ensure function and class names are preserved during minification (removing the need for a separate Terser configuration).
 
 Fixes [#836](https://github.com/equinor/fusion/issues/836)

--- a/packages/date/src/DateRange.tsx
+++ b/packages/date/src/DateRange.tsx
@@ -27,6 +27,8 @@ export const DateRange = createComponent<HTMLDateRangeCustomElement, ElementProp
   dateRangeTag,
 );
 
+DateRange.displayName = 'DateRange';
+
 export type DateRangeProps = ComponentProps<HTMLDateRangeCustomElement, ElementProps>;
 
 export { HTMLDateRangeCustomElement };

--- a/packages/date/src/DateTime.tsx
+++ b/packages/date/src/DateTime.tsx
@@ -11,6 +11,8 @@ export const DateTime = createComponent<HTMLDateTimeCustomElement, ElementProps>
   dateTimeTag,
 );
 
+DateTime.displayName = 'DateTime';
+
 export type DateTimeProps = ComponentProps<HTMLDateTimeCustomElement, ElementProps>;
 
 export { HTMLDateTimeCustomElement };

--- a/packages/list/src/components/CheckListItem.tsx
+++ b/packages/list/src/components/CheckListItem.tsx
@@ -30,6 +30,8 @@ export const CheckListItem = createComponent<HTMLCheckListItemCustomElement, Ele
   tag,
 );
 
+CheckListItem.displayName = 'CheckListItem';
+
 export type CheckListItemProps = ComponentProps<HTMLCheckListItemCustomElement, ElementProps>;
 
 export { HTMLCheckListItemCustomElement };

--- a/packages/list/src/components/List.tsx
+++ b/packages/list/src/components/List.tsx
@@ -23,6 +23,9 @@ export const List = createComponent<HTMLListCustomElement, ElementProps>(
   HTMLListCustomElement,
   tag,
 );
+
+List.displayName = 'List';
+
 export type ListProps = ComponentProps<HTMLListCustomElement, ElementProps>;
 
 export { HTMLListCustomElement };

--- a/packages/list/src/components/ListItem.tsx
+++ b/packages/list/src/components/ListItem.tsx
@@ -28,6 +28,9 @@ export const ListItem = createComponent<HTMLListItemCustomElement, ElementProps>
   HTMLListItemCustomElement,
   tag,
 );
+
+ListItem.displayName = 'ListItem';
+
 export type ListItemProps = ComponentProps<HTMLListItemCustomElement, ElementProps>;
 
 export { HTMLListItemCustomElement };

--- a/packages/list/src/components/RadioListItem.tsx
+++ b/packages/list/src/components/RadioListItem.tsx
@@ -29,6 +29,9 @@ export const RadioListItem = createComponent<HTMLRadioListItemCustomElement, Ele
   HTMLRadioListItemCustomElement,
   tag,
 );
+
+RadioListItem.displayName = 'RadioListItem';
+
 export type RadioListItemProps = ComponentProps<HTMLRadioListItemCustomElement, ElementProps>;
 
 export { HTMLRadioListItemCustomElement };

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -17,6 +17,8 @@ export const MarkdownEditor = createComponent<MarkdownEditorElement, ElementProp
   { events: { onInput: 'markdownEvent' } },
 );
 
+MarkdownEditor.displayName = 'MarkdownEditor';
+
 export { MarkdownEditorElement as HTMLMarkdownEditorCustomElement, type MenuSizes };
 
 export default MarkdownEditor;

--- a/packages/markdown/src/MarkdownViewer.tsx
+++ b/packages/markdown/src/MarkdownViewer.tsx
@@ -10,6 +10,8 @@ export const MarkdownViewer = createComponent<MarkdownViewerElement, ElementProp
   markdownViewerTag,
 );
 
+MarkdownViewer.displayName = 'MarkdownViewer';
+
 export { MarkdownViewerElement as HTMLMarkdownViewerCustomElement };
 
 export default MarkdownViewer;

--- a/packages/person/src/PersonAvatar.tsx
+++ b/packages/person/src/PersonAvatar.tsx
@@ -30,5 +30,7 @@ export const PersonAvatar = createComponent<HTMLPersonAvatarCustomElement, Eleme
   tag,
 );
 
+PersonAvatar.displayName = 'PersonAvatar';
+
 export type { HTMLPersonAvatarCustomElement, AvatarData };
 export default PersonAvatar;

--- a/packages/person/src/PersonCard.tsx
+++ b/packages/person/src/PersonCard.tsx
@@ -18,5 +18,7 @@ export const PersonCard = createComponent<HTMLPersonCardCustomElement, ElementPr
   tag,
 );
 
+PersonCard.displayName = 'PersonCard';
+
 export type { HTMLPersonCardCustomElement, PersonItemSize, CardData };
 export default PersonCard;

--- a/packages/person/src/PersonCell.tsx
+++ b/packages/person/src/PersonCell.tsx
@@ -27,5 +27,7 @@ export const PersonCell = createComponent<HTMLPersonCellCustomElement, ElementPr
   tag,
 );
 
+PersonCell.displayName = 'PersonCell';
+
 export type { PersonCellData, HTMLPersonCellCustomElement };
 export default PersonCell;

--- a/packages/person/src/PersonListItem.tsx
+++ b/packages/person/src/PersonListItem.tsx
@@ -20,5 +20,7 @@ export const PersonListItem = createComponent<HTMLPersonListItemCustomElement, E
   tag,
 );
 
+PersonListItem.displayName = 'PersonListItem';
+
 export type { ListItemData, HTMLPersonListItemCustomElement };
 export default PersonListItem;

--- a/packages/person/src/PersonSelect.tsx
+++ b/packages/person/src/PersonSelect.tsx
@@ -45,4 +45,6 @@ export const PersonSelect = createComponent<HTMLPersonSelectCustomElement, Eleme
   { events: { onSelect: 'select', onDropdownClosed: 'dropdownClosed' } },
 );
 
+PersonSelect.displayName = 'PersonSelect';
+
 export default PersonSelect;

--- a/packages/ripple/src/Ripple.tsx
+++ b/packages/ripple/src/Ripple.tsx
@@ -24,6 +24,8 @@ export const Ripple = createComponent<HTMLRippleCustomElement, ElementProps>(
   tag,
 );
 
+Ripple.displayName = 'Ripple';
+
 export type RippleProps = ComponentProps<typeof Ripple>;
 
 export default Ripple;

--- a/packages/ripple/src/index.tsx
+++ b/packages/ripple/src/index.tsx
@@ -20,6 +20,8 @@ export const Ripple = createComponent<HTMLRippleCustomElement, ElementProps>(
   tag,
 );
 
+Ripple.displayName = 'Ripple';
+
 export type RippleProps = ComponentProps<HTMLRippleCustomElement, ElementProps>;
 
 export { HTMLRippleCustomElement, RippleElement, RippleHandlers };

--- a/packages/searchable-dropdown/src/Dropdown.tsx
+++ b/packages/searchable-dropdown/src/Dropdown.tsx
@@ -34,4 +34,6 @@ export const Dropdown = createComponent<SearchableDropdownElement, ElementProps>
   { events: { onSelect: 'select', onDropdownClosed: 'dropdownClosed' } },
 );
 
+Dropdown.displayName = 'Dropdown';
+
 export default Dropdown;

--- a/packages/searchable-dropdown/src/DropdownProvider.tsx
+++ b/packages/searchable-dropdown/src/DropdownProvider.tsx
@@ -6,4 +6,6 @@ export const DropdownProvider = createComponent(
   'fwc-searchable-dropdown-provider',
 );
 
+DropdownProvider.displayName = 'DropdownProvider';
+
 export default DropdownProvider;

--- a/packages/skeleton/src/Skeleton.tsx
+++ b/packages/skeleton/src/Skeleton.tsx
@@ -16,6 +16,8 @@ export const Skeleton = createComponent<HTMLSkeletonCustomElement, ElementProps>
   tag,
 );
 
+Skeleton.displayName = 'Skeleton';
+
 export type SkeletonProps = ComponentProps<HTMLSkeletonCustomElement>;
 
 export { HTMLSkeletonCustomElement, SkeletonVariant, SkeletonSize };

--- a/packages/textarea/src/TextArea.tsx
+++ b/packages/textarea/src/TextArea.tsx
@@ -47,6 +47,8 @@ export const TextInput = createComponent<TextAreaElement, ElementProps>(TextArea
   functions: new Set(['validityTransform']),
 });
 
+TextInput.displayName = 'TextInput';
+
 export type TextInputProps = ComponentProps<TextAreaElement, ElementProps>;
 
 export default TextInput;

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -35,6 +35,15 @@ const config: StorybookConfig = {
           loose: true,
         }),
       ],
+      build: {
+        minify: 'terser',
+        minifyOptions: {
+          mangle: {
+            keep_fnames: true,
+            keep_classnames: true,
+          },
+        },
+      },
     });
   },
 

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -35,12 +35,18 @@ const config: StorybookConfig = {
           loose: true,
         }),
       ],
+      esbuild: {
+        keepNames: true,
+      },
       build: {
         minify: 'terser',
-        minifyOptions: {
+        terserOptions: {
+          compress: {
+            passes: 2,
+          },
           mangle: {
-            keep_fnames: true,
             keep_classnames: true,
+            keep_fnames: true,
           },
         },
       },

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -37,19 +37,7 @@ const config: StorybookConfig = {
       ],
       esbuild: {
         keepNames: true,
-      },
-      build: {
-        minify: 'terser',
-        terserOptions: {
-          compress: {
-            passes: 2,
-          },
-          mangle: {
-            keep_classnames: true,
-            keep_fnames: true,
-          },
-        },
-      },
+      }
     });
   },
 

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -30,11 +30,7 @@ const preview: Preview = {
       },
     },
     docs: {
-      source: {
-        language: 'tsx'
-      },
-
-      codePanel: true
+      codePanel: true,
     },
   },
  


### PR DESCRIPTION
Fix Storybook docs component names in production

When Storybook is built for production, code examples now keep readable component names instead of showing generic values like `<no />`.

This combines two fixes:

- Storybook Vite production build now preserves function and class names during minification.
- React wrapper components created with `createComponent(...)` now set explicit `displayName` values across packages so runtime JSX serialization can keep meaningful names.

Fixes [#836](https://github.com/equinor/fusion/issues/836)
