### PR TITLE
fix: update changeset publish script to use correct command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "storybook": "bun run --cwd ./storybook start",
     "storybook:build": "bun run --cwd ./storybook build",
     "changeset:version": "changeset version && bun install",
-    "changeset:publish": "changeset tag && npm publish --workspaces",
+    "changeset:publish": "changeset publish",
     "changeset:publish:pre-release": "npm publish --workspaces --tag ${NPM_TAG}"
   },
   "repository": {


### PR DESCRIPTION
Uses `changeset publish`as publishing command