### PR TITLE
fix: specify version for @equinor/fusion-react-utils in package.json

### DIFF
--- a/.changeset/nine-dragons-enjoy.md
+++ b/.changeset/nine-dragons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-react-person": patch
+---
+
+Fixes reference to `@equinor/fusion-react-utils`

--- a/packages/person/package.json
+++ b/packages/person/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/equinor/fusion-react-components/issues"
   },
   "dependencies": {
-    "@equinor/fusion-react-utils": "workspace:^",
+    "@equinor/fusion-react-utils": "3.0.2",
     "@equinor/fusion-wc-people": "2.2.2",
     "@equinor/fusion-wc-person": "3.5.4"
   },


### PR DESCRIPTION
Fixes reference to `@equinor/fusion-react-utils` in `@equinor/fusion-react-person`