### PR TITLE
chore: update @equinor/fusion-wc-people dependency to version 2.2.4

### DIFF
--- a/.changeset/person_update-wc-people.md
+++ b/.changeset/person_update-wc-people.md
@@ -1,0 +1,8 @@
+---
+"@equinor/fusion-react-person": patch
+---
+
+Update the bundled people web component dependency.
+
+- Pick up the latest `@equinor/fusion-wc-people` patch release.
+- Keep the person package aligned with the current web component dependency range.

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "components": {
       "name": "@equinor/fusion-react-components",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@equinor/fusion-react-person": "workspace:*",
       },
@@ -29,7 +29,7 @@
     },
     "packages/ag-grid-person-cell": {
       "name": "@equinor/fusion-react-ag-grid-person-cell",
-      "version": "4.0.9",
+      "version": "4.0.10",
       "dependencies": {
         "@equinor/fusion-react-person": "workspace:*",
         "@equinor/fusion-react-utils": "workspace:*",
@@ -213,11 +213,11 @@
     },
     "packages/person": {
       "name": "@equinor/fusion-react-person",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "dependencies": {
         "@equinor/fusion-react-utils": "workspace:*",
-        "@equinor/fusion-wc-people": "2.2.3",
-        "@equinor/fusion-wc-person": "3.5.5",
+        "@equinor/fusion-wc-people": "^2.2.4",
+        "@equinor/fusion-wc-person": "^3.5.5",
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
@@ -411,7 +411,7 @@
     },
     "storybook": {
       "name": "@equinor/fusion-react-components-stories",
-      "version": "6.0.7",
+      "version": "6.0.8",
       "dependencies": {
         "@babel/core": "^8.0.1",
         "@emotion/css": "^11.11.2",
@@ -895,7 +895,7 @@
 
     "@equinor/fusion-wc-markdown": ["@equinor/fusion-wc-markdown@1.6.3", "", { "dependencies": { "@equinor/fusion-wc-core": "^2.0.3", "@equinor/fusion-wc-icon": "^2.4.3", "@equinor/fusion-web-theme": "^0.1.10", "lit": "3.3.2", "marked": "^18.0.3", "prismjs": "^1.29.0", "prosemirror-commands": "^1.7.1", "prosemirror-history": "^1.5.0", "prosemirror-inputrules": "^1.5.1", "prosemirror-keymap": "^1.2.3", "prosemirror-markdown": "^1.13.4", "prosemirror-model": "^1.25.4", "prosemirror-schema-basic": "^1.2.4", "prosemirror-schema-list": "^1.5.1", "prosemirror-state": "^1.4.4", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8" } }, "sha512-+i+zyhSltXwgRmfuBBEBvvNpECPqBthbAQ5p0xteZyLOkxwuq19SUoIt2spy0UOamTOKsPVotPzePts8NTSHUQ=="],
 
-    "@equinor/fusion-wc-people": ["@equinor/fusion-wc-people@2.2.3", "", { "dependencies": { "@equinor/fusion-wc-button": "^2.5.3", "@equinor/fusion-wc-checkbox": "^1.2.3", "@equinor/fusion-wc-chip": "^1.3.3", "@equinor/fusion-wc-core": "^2.0.3", "@equinor/fusion-wc-formfield": "^1.2.3", "@equinor/fusion-wc-icon": "^2.4.3", "@equinor/fusion-wc-person": "^3.5.5", "@equinor/fusion-wc-progress-indicator": "^1.2.3", "@equinor/fusion-wc-skeleton": "^2.2.3", "@equinor/fusion-web-theme": "^0.1.10", "@lit/context": "^1.1.6", "@lit/task": "^1.0.3", "lit": "3.3.3" } }, "sha512-D0zE//XcAaKaf2DvnU+Nt55RGm3hU4/vdNY4dxHMoOnWN8UtPvvRzsUh6SxzzPCHeP/gAW9s6oI5lw3v9ttyAg=="],
+    "@equinor/fusion-wc-people": ["@equinor/fusion-wc-people@2.2.4", "", { "dependencies": { "@equinor/fusion-wc-button": "^2.5.3", "@equinor/fusion-wc-checkbox": "^1.2.3", "@equinor/fusion-wc-chip": "^1.3.3", "@equinor/fusion-wc-core": "^2.0.3", "@equinor/fusion-wc-formfield": "^1.2.3", "@equinor/fusion-wc-icon": "^2.4.3", "@equinor/fusion-wc-person": "^3.5.5", "@equinor/fusion-wc-progress-indicator": "^1.2.3", "@equinor/fusion-wc-skeleton": "^2.2.3", "@equinor/fusion-web-theme": "^0.1.10", "@lit/context": "^1.1.6", "@lit/task": "^1.0.3", "lit": "3.3.3" } }, "sha512-17CS6qmRiBEvMd7cjJpQm44pTQAEhDa+5T10n7pU9Or+cOx6LnxjwwPj4jeAmcncru2EmHF0bh6NAwinZuHDEg=="],
 
     "@equinor/fusion-wc-person": ["@equinor/fusion-wc-person@3.5.5", "", { "dependencies": { "@equinor/fusion-wc-button": "^2.5.3", "@equinor/fusion-wc-core": "^2.0.3", "@equinor/fusion-wc-icon": "^2.4.3", "@equinor/fusion-wc-list": "^1.2.3", "@equinor/fusion-wc-searchable-dropdown": "^4.1.3", "@equinor/fusion-wc-skeleton": "^2.2.3", "@equinor/fusion-wc-textinput": "^1.2.3", "@equinor/fusion-web-theme": "^0.1.10", "@floating-ui/dom": "^1.7.6", "@lit-labs/observers": "^2.1.0", "@lit/task": "^1.0.3", "lit": "3.3.3" } }, "sha512-FpGcicj1Cz7vVhMDYeUb8G66HNS8ttM66FgsDTYTZp9sHL2/KrigD26TeMGkxRjGgKRNRuiebaHfNwpkE/kreg=="],
 

--- a/packages/person/package.json
+++ b/packages/person/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@equinor/fusion-react-utils": "workspace:*",
-    "@equinor/fusion-wc-people": "2.2.3",
-    "@equinor/fusion-wc-person": "3.5.5"
+    "@equinor/fusion-wc-people": "^2.2.4",
+    "@equinor/fusion-wc-person": "^3.5.5"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",


### PR DESCRIPTION
# Component Development

### Type

- [ ] Feature
- [ ] Fix
- [ ] Hotfix (should release ASAP)
- [x] Maintenance (deps only)

### Reference to assignment

N/A

### Description of assignment

Update `@equinor/fusion-react-person` to use the latest `@equinor/fusion-wc-people` patch release.

### Description of Proposed Changes

- bump `@equinor/fusion-wc-people` from `2.2.3` to `^2.2.4`
- refresh `bun.lock`
- add a patch changeset for `@equinor/fusion-react-person`
