### PR TITLE
feat(context-selector): default topLayer to true for portal-safe rendering

### DIFF
--- a/.changeset/fusion-react-context-selector_default-top-layer.md
+++ b/.changeset/fusion-react-context-selector_default-top-layer.md
@@ -1,0 +1,16 @@
+---
+"@equinor/fusion-react-context-selector": minor
+---
+
+`ContextSelector` and `ContextSearch` now default the underlying `topLayer` prop to `true`,
+so context selector results render in the browser's top layer (via the Popover API) and
+reliably appear above any stacking context a hosting Fusion app happens to create, without
+app teams having to manage z-index. Pass `topLayer={false}` to opt back out.
+
+This default only takes effect once the `@equinor/fusion-wc-searchable-dropdown` dependency
+supports `topLayer` (added as a minor release from 4.1.3, expected `4.2.0` - see
+[equinor/fusion-web-components#2368](https://github.com/equinor/fusion-web-components/pull/2368)).
+Until that version is installed, setting `topLayer` is a harmless no-op and existing
+behavior is unchanged.
+
+Refs [equinor/fusion-core-tasks#1428](https://github.com/equinor/fusion-core-tasks/issues/1428).

--- a/.changeset/fusion-react-searchable-dropdown_top-layer-typing.md
+++ b/.changeset/fusion-react-searchable-dropdown_top-layer-typing.md
@@ -1,0 +1,17 @@
+---
+"@equinor/fusion-react-searchable-dropdown": minor
+---
+
+Adds type support for the upcoming `topLayer` boolean prop on `Dropdown`/`SearchableDropdown`,
+forwarded to the underlying `fwc-searchable-dropdown` element. When enabled, the result list
+renders in the browser's top layer via the native Popover API instead of a shadow-DOM-relative,
+absolutely positioned box, so it can reliably render above content with its own stacking
+context. Default behavior is unchanged (`topLayer` defaults to `false`, matching the
+underlying element).
+
+This prop only has an effect once the `@equinor/fusion-wc-searchable-dropdown` dependency
+supports `topLayer` (added as a minor release from 4.1.3, expected `4.2.0` - see
+[equinor/fusion-web-components#2368](https://github.com/equinor/fusion-web-components/pull/2368)).
+Until that version is installed, passing `topLayer` is a harmless no-op.
+
+Refs [equinor/fusion-core-tasks#1428](https://github.com/equinor/fusion-core-tasks/issues/1428).

--- a/packages/context-selector/README.md
+++ b/packages/context-selector/README.md
@@ -14,3 +14,28 @@ Built on Web-Component [Fusion Web Component](https://github.com/equinor/fusion-
 ```sh
 npm install @equinor/fusion-react-context-selector
 ```
+
+### Rendering above arbitrary Fusion app stacking contexts
+
+Context selector results are portal-owned UI: they must reliably render above whatever
+stacking context a hosting Fusion app happens to create (dialogs, transformed/filtered
+containers, etc.), without app teams having to manage z-index. `ContextSelector` and
+`ContextSearch` therefore default the underlying `topLayer` prop to `true`, rendering the
+result list in the browser's top layer via the native
+[Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) instead of a
+shadow-DOM-relative, absolutely positioned box. Falls back automatically to the previous
+behavior in browsers without Popover API support.
+
+Pass `topLayer={false}` explicitly to opt back out of this default:
+
+```tsx
+<ContextSearch topLayer={false} />
+```
+
+See [equinor/fusion-web-components#2368](https://github.com/equinor/fusion-web-components/pull/2368)
+and [equinor/fusion-core-tasks#1428](https://github.com/equinor/fusion-core-tasks/issues/1428).
+
+> **Note:** this default only takes effect once `@equinor/fusion-wc-searchable-dropdown` is
+> upgraded to a version that supports `topLayer` (published as a minor release from 4.1.3,
+> expected `4.2.0`). Until then, setting `topLayer` is a harmless no-op and behavior is
+> unchanged.

--- a/packages/context-selector/src/ContextSelector.tsx
+++ b/packages/context-selector/src/ContextSelector.tsx
@@ -4,9 +4,32 @@ import type { ReactElement, PropsWithChildren } from 'react';
 
 export const ContextSelector = ({
   children,
+  /**
+   * Context selector results are portal-owned UI: they must render above whatever
+   * stacking context a hosting Fusion app happens to create, without app teams having
+   * to manage z-index themselves. Defaulting `topLayer` to `true` renders the result
+   * list in the browser's top layer via the Popover API instead of a shadow-DOM-relative,
+   * absolutely positioned box. Pass `topLayer={false}` explicitly to opt back out.
+   *
+   * Falls back automatically to the previous behavior in browsers without Popover API
+   * support, and is a no-op no matter the value until the underlying
+   * `@equinor/fusion-wc-searchable-dropdown` dependency ships `topLayer` support.
+   *
+   * @see https://github.com/equinor/fusion-web-components/pull/2368
+   * @see https://github.com/equinor/fusion-core-tasks/issues/1428
+   */
+  topLayer = true,
   ...props
 }: PropsWithChildren<ContextSelectorProps>): ReactElement => {
-  return <Dropdown {...props}>{children}</Dropdown>;
+  return (
+    /**
+     * `topLayer` is merged into a single spread object (rather than passed as a
+     * separate JSX attribute) so TypeScript's excess-property checking for
+     * `Dropdown` (whose props intentionally omit `children`) doesn't reject the
+     * `children` prop this component always forwards.
+     */
+    <Dropdown {...{ topLayer, ...props }}>{children}</Dropdown>
+  );
 };
 
 ContextSelector.displayName = 'ContextSelector';

--- a/packages/context-selector/src/wc-searchable-dropdown.d.ts
+++ b/packages/context-selector/src/wc-searchable-dropdown.d.ts
@@ -1,0 +1,41 @@
+/**
+ * TEMPORARY type augmentation - delete once `@equinor/fusion-wc-searchable-dropdown@4.2.0`
+ * (or later) is published and installed.
+ *
+ * `@equinor/fusion-wc-searchable-dropdown` gains an opt-in `topLayer` boolean property
+ * (`top-layer` attribute) in equinor/fusion-web-components#2368, tracked by
+ * equinor/fusion-core-tasks#1428. That change ships as a **minor** release, so the
+ * existing `^4.1.1` dependency range already permits it once published - no dependency
+ * bump is required here. At the time this file was authored, that release did not yet
+ * exist on npm, so the currently installed version does not declare `topLayer` on its
+ * runtime prototype.
+ *
+ * This augmentation exists purely so `topLayer` type-checks as a valid prop on
+ * `Dropdown`/`ContextSelector` today. It has **no runtime effect**: `createComponent`
+ * (see `packages/utils/src/hooks/useElementProps.ts`) forwards properties by inspecting
+ * the actual installed custom element's prototype, so setting `topLayer` against a
+ * pre-4.2.0 build of `fwc-searchable-dropdown` is a harmless no-op - the result list
+ * keeps its existing (non-top-layer) rendering until the dependency is upgraded.
+ * No other code changes are needed once that version is installed.
+ */
+export {};
+
+declare module '@equinor/fusion-wc-searchable-dropdown' {
+  interface SearchableDropdownProps {
+    /**
+     * Render the result list in the browser's top layer using the native
+     * {@link https://developer.mozilla.org/docs/Web/API/Popover_API | Popover API}
+     * (`popover="manual"`) instead of a shadow-DOM-relative, absolutely positioned box,
+     * so it can reliably render above content that creates its own independent
+     * stacking context elsewhere in the host application. Falls back automatically to
+     * the previous behavior when the Popover API is unsupported.
+     *
+     * @defaultValue false
+     */
+    topLayer?: boolean;
+  }
+
+  interface SearchableDropdownElement {
+    topLayer: boolean;
+  }
+}

--- a/packages/searchable-dropdown/README.md
+++ b/packages/searchable-dropdown/README.md
@@ -13,3 +13,22 @@
 ```sh
 npm install @equinor/fusion-react-searchable-dropdown
 ```
+
+### Rendering the result list above arbitrary stacking contexts
+
+`Dropdown`/`SearchableDropdown` forward an opt-in `topLayer` boolean prop (default `false`,
+matching the underlying `fwc-searchable-dropdown` element) to render the result list in the
+browser's top layer via the native
+[Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) instead of a
+shadow-DOM-relative, absolutely positioned box. This is useful when the result list must
+reliably render above content that creates its own independent stacking context. Falls back
+automatically to the previous behavior when the Popover API is unsupported.
+
+```tsx
+<Dropdown topLayer />
+```
+
+> `@equinor/fusion-react-context-selector` enables `topLayer` by default, since context
+> selector results are portal-owned UI that must render above arbitrary Fusion app stacking
+> contexts. See [equinor/fusion-web-components#2368](https://github.com/equinor/fusion-web-components/pull/2368)
+> and [equinor/fusion-core-tasks#1428](https://github.com/equinor/fusion-core-tasks/issues/1428).

--- a/packages/searchable-dropdown/src/wc-searchable-dropdown.d.ts
+++ b/packages/searchable-dropdown/src/wc-searchable-dropdown.d.ts
@@ -1,0 +1,41 @@
+/**
+ * TEMPORARY type augmentation - delete once `@equinor/fusion-wc-searchable-dropdown@4.2.0`
+ * (or later) is published and installed.
+ *
+ * `@equinor/fusion-wc-searchable-dropdown` gains an opt-in `topLayer` boolean property
+ * (`top-layer` attribute) in equinor/fusion-web-components#2368, tracked by
+ * equinor/fusion-core-tasks#1428. That change ships as a **minor** release, so the
+ * existing `^4.1.1` dependency range already permits it once published - no dependency
+ * bump is required here. At the time this file was authored, that release did not yet
+ * exist on npm, so the currently installed version does not declare `topLayer` on its
+ * runtime prototype.
+ *
+ * This augmentation exists purely so `topLayer` type-checks as a valid prop on
+ * `Dropdown`/`ContextSelector` today. It has **no runtime effect**: `createComponent`
+ * (see `packages/utils/src/hooks/useElementProps.ts`) forwards properties by inspecting
+ * the actual installed custom element's prototype, so setting `topLayer` against a
+ * pre-4.2.0 build of `fwc-searchable-dropdown` is a harmless no-op - the result list
+ * keeps its existing (non-top-layer) rendering until the dependency is upgraded.
+ * No other code changes are needed once that version is installed.
+ */
+export {};
+
+declare module '@equinor/fusion-wc-searchable-dropdown' {
+  interface SearchableDropdownProps {
+    /**
+     * Render the result list in the browser's top layer using the native
+     * {@link https://developer.mozilla.org/docs/Web/API/Popover_API | Popover API}
+     * (`popover="manual"`) instead of a shadow-DOM-relative, absolutely positioned box,
+     * so it can reliably render above content that creates its own independent
+     * stacking context elsewhere in the host application. Falls back automatically to
+     * the previous behavior when the Popover API is unsupported.
+     *
+     * @defaultValue false
+     */
+    topLayer?: boolean;
+  }
+
+  interface SearchableDropdownElement {
+    topLayer: boolean;
+  }
+}

--- a/storybook/src/stories/context-selector/context-selector.mdx
+++ b/storybook/src/stories/context-selector/context-selector.mdx
@@ -20,6 +20,15 @@ import * as stories from './context-selector.stories';
 
 <Canvas of={stories.ContextHeader} />
 
+### Rendering above arbitrary Fusion app stacking contexts
+
+Context selector results are portal-owned UI: they must reliably render above whatever
+stacking context a hosting Fusion app happens to create, without app teams having to manage
+z-index. `topLayer` therefore defaults to `true`, rendering results in the browser's top
+layer via the native Popover API. Pass `topLayer={false}` to opt back out.
+
+<Canvas of={stories.ContextHeaderTopLayerDisabled} />
+
 ## ChangeLog
 
 <ChangeLog

--- a/storybook/src/stories/context-selector/context-selector.stories.tsx
+++ b/storybook/src/stories/context-selector/context-selector.stories.tsx
@@ -1,14 +1,15 @@
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta, StoryObj } from "@storybook/react-vite";
 import {
   ContextProvider,
   ContextSelector,
   ContextSearch,
   ContextSelectEvent,
-} from '@equinor/fusion-react-context-selector/src';
-import { _exampleResolver } from './context-selector.helpers';
+} from "@equinor/fusion-react-context-selector/src";
+import { Typography } from "@equinor/eds-core-react";
+import { _exampleResolver } from "./context-selector.helpers";
 
 const meta: Meta<typeof ContextSearch> = {
-  title: 'data/ContextSelector',
+  title: "data/ContextSelector",
   component: ContextSelector,
 };
 
@@ -18,16 +19,16 @@ type Story = StoryObj<typeof ContextSearch>;
 
 export const ContextHeader: Story = {
   args: {
-    placeholder: 'Start to type to search...',
-    initialText: 'The initial text result',
-    variant: 'header',
-    dropdownHeight: '300px',
+    placeholder: "Start to type to search...",
+    initialText: "The initial text result",
+    variant: "header",
+    dropdownHeight: "300px",
     onSelect: (e: ContextSelectEvent) => {
       e.stopPropagation();
-      console.log('Event', e.type, 'fired. Object:', e);
+      console.log("Event", e.type, "fired. Object:", e);
     },
     onClearContext: () => {
-      console.log('Context Clearing');
+      console.log("Context Clearing");
     },
   },
   render: (args) => (
@@ -50,4 +51,42 @@ export const ContextHeaderTopLayerDisabled: Story = {
     ...ContextHeader.args,
     topLayer: false,
   },
+  render: (args) => (
+    <div
+      style={{
+        position: "relative",
+        transform: "translateZ(0)",
+        padding: "2rem 1rem 260px",
+        border: "1px dashed gray",
+      }}
+    >
+      <Typography style={{ margin: "0 0 1rem" }}>
+        This box creates its own stacking context via transform: translateZ(0).
+        The overlay directly below the input uses z-index: 999, exactly where
+        the result list opens. Toggle topLayer in the Controls panel to compare.
+      </Typography>
+      <div style={{ position: "relative" }}>
+        <ContextProvider resolver={_exampleResolver}>
+          <ContextSearch {...args} />
+        </ContextProvider>
+        <div
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            right: 0,
+            height: "200px",
+            zIndex: 999,
+            background: "rgba(226, 6, 44, 0.25)",
+            textAlign: "center",
+            paddingTop: "0.5rem",
+          }}
+        >
+          <Typography>
+            Overlay with its own stacking context (z-index: 999)
+          </Typography>
+        </div>
+      </div>
+    </div>
+  ),
 };

--- a/storybook/src/stories/context-selector/context-selector.stories.tsx
+++ b/storybook/src/stories/context-selector/context-selector.stories.tsx
@@ -1,15 +1,15 @@
-import { Meta, StoryObj } from "@storybook/react-vite";
+import { Meta, StoryObj } from '@storybook/react-vite';
 import {
   ContextProvider,
   ContextSelector,
   ContextSearch,
   ContextSelectEvent,
-} from "@equinor/fusion-react-context-selector/src";
-import { Typography } from "@equinor/eds-core-react";
-import { _exampleResolver } from "./context-selector.helpers";
+} from '@equinor/fusion-react-context-selector/src';
+import { Typography } from '@equinor/eds-core-react';
+import { _exampleResolver } from './context-selector.helpers';
 
 const meta: Meta<typeof ContextSearch> = {
-  title: "data/ContextSelector",
+  title: 'data/ContextSelector',
   component: ContextSelector,
 };
 
@@ -19,16 +19,16 @@ type Story = StoryObj<typeof ContextSearch>;
 
 export const ContextHeader: Story = {
   args: {
-    placeholder: "Start to type to search...",
-    initialText: "The initial text result",
-    variant: "header",
-    dropdownHeight: "300px",
+    placeholder: 'Start to type to search...',
+    initialText: 'The initial text result',
+    variant: 'header',
+    dropdownHeight: '300px',
     onSelect: (e: ContextSelectEvent) => {
       e.stopPropagation();
-      console.log("Event", e.type, "fired. Object:", e);
+      console.log('Event', e.type, 'fired. Object:', e);
     },
     onClearContext: () => {
-      console.log("Context Clearing");
+      console.log('Context Clearing');
     },
   },
   render: (args) => (
@@ -54,32 +54,32 @@ export const ContextHeaderTopLayerDisabled: Story = {
   render: (args) => (
     <div
       style={{
-        position: "relative",
-        transform: "translateZ(0)",
-        padding: "2rem 1rem 260px",
-        border: "1px dashed gray",
+        position: 'relative',
+        transform: 'translateZ(0)',
+        padding: '2rem 1rem 260px',
+        border: '1px dashed gray',
       }}
     >
-      <Typography style={{ margin: "0 0 1rem" }}>
+      <Typography style={{ margin: '0 0 1rem' }}>
         This box creates its own stacking context via transform: translateZ(0).
         The overlay directly below the input uses z-index: 999, exactly where
         the result list opens. Toggle topLayer in the Controls panel to compare.
       </Typography>
-      <div style={{ position: "relative" }}>
+      <div style={{ position: 'relative' }}>
         <ContextProvider resolver={_exampleResolver}>
           <ContextSearch {...args} />
         </ContextProvider>
         <div
           style={{
-            position: "absolute",
-            top: "100%",
+            position: 'absolute',
+            top: '100%',
             left: 0,
             right: 0,
-            height: "200px",
+            height: '200px',
             zIndex: 999,
-            background: "rgba(226, 6, 44, 0.25)",
-            textAlign: "center",
-            paddingTop: "0.5rem",
+            background: 'rgba(226, 6, 44, 0.25)',
+            textAlign: 'center',
+            paddingTop: '0.5rem',
           }}
         >
           <Typography>

--- a/storybook/src/stories/context-selector/context-selector.stories.tsx
+++ b/storybook/src/stories/context-selector/context-selector.stories.tsx
@@ -36,3 +36,18 @@ export const ContextHeader: Story = {
     </ContextProvider>
   ),
 };
+
+/**
+ * `topLayer` defaults to `true` for context selector results (see the
+ * "Rendering above arbitrary Fusion app stacking contexts" section in the package
+ * README), so results render in the browser's top layer and can't be clipped or
+ * hidden behind app content with its own stacking context. Pass `topLayer={false}`
+ * to opt back into the previous shadow-DOM-relative, absolutely positioned behavior.
+ */
+export const ContextHeaderTopLayerDisabled: Story = {
+  ...ContextHeader,
+  args: {
+    ...ContextHeader.args,
+    topLayer: false,
+  },
+};

--- a/storybook/src/stories/searchable-dropdown/searchable-dropdown.mdx
+++ b/storybook/src/stories/searchable-dropdown/searchable-dropdown.mdx
@@ -16,6 +16,14 @@ import * as stories from './searchable-dropdown.stories';
 <ArgTypes of={ stories.basic } />
 <Canvas of={ stories.basic } meta={stories} story={{height: '320px'}}/>
 
+## Rendering above stacking contexts
+
+Enable `topLayer` to render the result list above independently created
+stacking contexts. Toggle the control in this example to compare the default
+positioning with browser top-layer rendering.
+
+<Canvas of={ stories.TopLayer } meta={stories} story={{height: '560px'}}/>
+
 ## How to use
 
 The ``searchable-dropdown`` component is built up of 2 elements, ``dropdown`` and ``dropdownProvider``.

--- a/storybook/src/stories/searchable-dropdown/searchable-dropdown.stories.tsx
+++ b/storybook/src/stories/searchable-dropdown/searchable-dropdown.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Meta, StoryObj } from '@storybook/react-vite';
 
+import { Typography } from '@equinor/eds-core-react';
 import { SearchableDropdown } from '@equinor/fusion-react-searchable-dropdown/src/SearchableDropdown';
 
 // TODO - simplify
@@ -48,4 +49,52 @@ export const multiple: Story = {
   render: (props) => {
     return <SearchableDropdown {...props} />;
   },
+};
+
+/**
+ * Demonstrates how `topLayer` lets the result list escape an independently
+ * created stacking context and render above an overlapping element.
+ */
+export const TopLayer: Story = {
+  ...basic,
+  args: {
+    ...basic.args,
+    topLayer: false,
+  },
+  render: (args) => (
+    <div
+      style={{
+        position: 'relative',
+        transform: 'translateZ(0)',
+        padding: '2rem 1rem 260px',
+        border: '1px dashed gray',
+      }}
+    >
+      <Typography style={{ margin: '0 0 1rem' }}>
+        This box creates its own stacking context via transform: translateZ(0).
+        The overlay directly below the input uses z-index: 999, exactly where
+        the result list opens. Toggle topLayer in the Controls panel to compare.
+      </Typography>
+      <div style={{ position: 'relative' }}>
+        <SearchableDropdown {...args} />
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            height: '200px',
+            zIndex: 999,
+            background: 'rgba(226, 6, 44, 0.25)',
+            textAlign: 'center',
+            paddingTop: '0.5rem',
+          }}
+        >
+          <Typography>
+            Overlay with its own stacking context (z-index: 999)
+          </Typography>
+        </div>
+      </div>
+    </div>
+  ),
 };


### PR DESCRIPTION
## Component Development

### Type

- [x] Feature

### Reference to assignment

Refs equinor/fusion-core-tasks#1428
Refs equinor/fusion-web-components#2368 (coordinated PR adding the underlying `topLayer` property to `@equinor/fusion-wc-searchable-dropdown`)

### Description of assignment

Context selector results are portal-owned UI that must render above whatever stacking context a hosting Fusion app happens to create, without app teams having to manage z-index themselves. `equinor/fusion-web-components#2368` adds an opt-in, boolean `topLayer` property (default `false`, reflected as `top-layer`) to `@equinor/fusion-wc-searchable-dropdown` that renders the dropdown popover via the native Popover API / browser top layer, falling back to current behavior when unsupported. This PR is the React/shared-component half: it makes `@equinor/fusion-react-context-selector` enable that behavior **by default**, while leaving the generic `@equinor/fusion-react-searchable-dropdown` package's default unchanged.

### Description of Proposed Changes

- **`@equinor/fusion-react-context-selector`**: `ContextSelector` (and, transitively, `ContextSearch`, which forwards unrecognized props) now defaults `topLayer` to `true`. Consumers can still explicitly pass `topLayer={false}` to opt back out — the existing prop surface already supports overriding it, no new API was introduced for this.
- **`@equinor/fusion-react-searchable-dropdown`**: no behavioral change. `Dropdown`/`SearchableDropdown` keep their generic default (`topLayer` unset/`false`), only gaining typed pass-through support for the new prop.
- **Temporary ambient type augmentation** (`wc-searchable-dropdown.d.ts` in both `packages/searchable-dropdown/src` and `packages/context-selector/src` — duplicated because this monorepo's TS project references don't propagate ambient augmentations across referenced projects): types `topLayer` on `SearchableDropdownProps`/`SearchableDropdownElement` today, ahead of the real upstream release. Heavily documented as temporary and safe to delete once the real dependency ships.
- **Dependency**: `@equinor/fusion-wc-searchable-dropdown`'s changeset in fusion-web-components#2368 is `minor` from the current published `4.1.3`, so the expected next release is `4.2.0` — **not yet published** (verified via `npm view @equinor/fusion-wc-searchable-dropdown versions`). The dependency range in both `package.json` files is intentionally left at `^4.1.1`, which already permits `4.2.0` once published; explicitly bumping to `^4.2.0` today breaks `bun install` for the whole workspace since that version doesn't exist yet (verified). No `bun.lock` changes were needed as a result.
  - **Runtime behavior today**: `@equinor/fusion-wc-searchable-dropdown` prop-forwarding (`extractElementProps` in `packages/utils`) inspects the actual runtime prototype of the installed custom element class, not TypeScript types. Against the currently-installed `4.1.3` (which lacks `topLayer`), setting `topLayer` is a **harmless no-op** — it's treated as an unrecognized attribute. Once `4.2.0`+ is installed, the exact same code starts rendering via the top layer with **no further code changes required** — only delete the two temporary `.d.ts` files.
- Docs: updated `packages/context-selector/README.md` and `packages/searchable-dropdown/README.md` with new sections explaining the default/opt-in behavior, override syntax, and the no-op caveat.
- Storybook: added a `ContextHeaderTopLayerDisabled` story and docs section. The story mirrors fusion-web-components#2368 with a transformed stacking-context container and a `z-index: 999` overlay directly below the input, so toggling `topLayer` in Controls visibly demonstrates the result list moving above the overlay.
- Changesets: added minor changesets for both `@equinor/fusion-react-context-selector` and `@equinor/fusion-react-searchable-dropdown`.

### Validation

- `bun run build` — full monorepo (21 packages) builds cleanly, including both touched packages.
- `bun run storybook:build` — Storybook production bundle builds successfully with the overlay story.
- `bunx biome check` — clean on all new/changed `.ts`/`.tsx` files covered by the repository Biome configuration.
- `bunx changeset status` — correctly reports minor bumps for both packages.
- Storybook `tsc -b` has pre-existing, unrelated TS errors across several packages; confirmed via `git stash` comparison that the exact same error set exists with and without this change (zero new errors introduced).
- `bun run lint` (biome, whole repo) — the ~40 warnings surfaced are all in pre-existing, unrelated files (e.g. `scripts/publish.js`); zero warnings in files touched by this change.

### Known blocker / follow-up

- **Upstream dependency**: this draft PR is held until fusion-web-components#2368 publishes `@equinor/fusion-wc-searchable-dropdown@4.2.0`, so the temporary ambient augmentations can be removed, the real dependency explicitly installed, and top-layer behavior validated against the published package.

## Checklist

#### Development

- [x] Describe the component
- [x] Code functional requirements
- [x] Create stories
- [x] Remove unused imports and commented code
- [x] Lint code with Biome

#### Create Pull Request

- [ ] Assign relevant reviewers in Github and Cromatic
- [ ] Inform colleagues of pending reviews (Teams, fusion-frontend Code review channel)

#### Publish Code

- [ ] Increment version number
- [ ] Merge PR

---

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
