### PR TITLE
Fix/filter/max depth observable

### DIFF
--- a/.changeset/stable-filter-selector.md
+++ b/.changeset/stable-filter-selector.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-react-filter": patch
+---
+
+Prevent `FilterOptionHeader` from entering an infinite render loop after upgrading `@equinor/fusion-observable` by keeping its selection count selector stable across renders.

--- a/packages/filter/src/components/filter/FilterOptionHeader.tsx
+++ b/packages/filter/src/components/filter/FilterOptionHeader.tsx
@@ -14,6 +14,8 @@ type FilterHeaderProps = {
   readonly title: string;
 };
 
+const getSelectedCount = (selection?: Set<unknown>): number => selection?.size ?? 0;
+
 const Styled = {
   Root: styled.div`
     display: flex;
@@ -63,7 +65,7 @@ export const FilterOptionHeader = (props: FilterHeaderProps): ReactElement => {
   const { options$, selection$ } = useFilterOptionContext();
   const optionCount = Object.keys(useObservableState(options$).value || {}).length;
   const { value: selectedCount } = useObservableState(
-    useObservableSelector(selection$, (x) => (x ?? new Set()).size),
+    useObservableSelector(selection$, getSelectedCount),
     { initial: 0 },
   );
 


### PR DESCRIPTION
## Why

After upgrading `@equinor/fusion-observable`, `FilterOptionHeader` entered an infinite render loop because its inline selector created a new derived observable on every render.

## What changed

- Stabilized the selection-count selector across renders
- Prevented `useObservableState` from repeatedly resubscribing
- Preserved the existing selected-option count behavior
- Added a patch changeset for `@equinor/fusion-react-filter`

## Validation

- `bun run --cwd packages/filter build`
- Verified the filter renders without the maximum update depth error
- Biome CI passes

## Reference

Related to https://github.com/equinor/fusion/issues/889